### PR TITLE
Allow specification of a client name or set of scopes on Blueprint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # whattimeisitrightnow example provider's database file
 whattimeisitrightnow.example.db
+
+# Emacs config
+.dir-locals.el

--- a/globus_action_provider_tools/authentication.py
+++ b/globus_action_provider_tools/authentication.py
@@ -83,7 +83,7 @@ class AuthState(object):
             aud = resp.get("aud", [])
             assert (
                 self.expected_audience in aud
-            ), f"Token not intended for us: audience={aud}"
+            ), f"Token not intended for us: audience={aud}, expected={self.expected_audience}"
             assert "identity_set" in resp, "Missing identity_set"
         except AssertionError as err:
             our_err = TokenValidationError(err)

--- a/globus_action_provider_tools/flask/apt_blueprint.py
+++ b/globus_action_provider_tools/flask/apt_blueprint.py
@@ -6,10 +6,6 @@ from functools import singledispatch, update_wrapper
 from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
 
 from flask import Blueprint, Response, current_app, g, jsonify, request
-from globus_action_provider_tools.flask import (
-    blueprint_error_handler,
-    flask_validate_request,
-)
 from jsonschema.validators import Draft7Validator
 from werkzeug.exceptions import BadRequest, NotFound, NotImplemented, Unauthorized
 
@@ -25,7 +21,10 @@ from globus_action_provider_tools.data_types import (
     ActionStatus,
     AuthState,
 )
-
+from globus_action_provider_tools.flask import (
+    blueprint_error_handler,
+    flask_validate_request,
+)
 
 ActionStatusReturn = Union[ActionStatus, Tuple[ActionStatus, int]]
 ActionLogReturn = Dict[str, Any]
@@ -107,8 +106,8 @@ class ActionProviderBlueprint(Blueprint):
 
         super().__init__(*args, **kwarg)
 
-        self.action_status_plugin: ActionStatusType = None
-        self.action_cancel_plugin: ActionCancelType = None
+        self.action_status_plugin: Optional[ActionStatusType] = None
+        self.action_cancel_plugin: Optional[ActionCancelType] = None
         self.action_loader_plugin = None
         self.action_saver_plugin = None
 


### PR DESCRIPTION
THis allows the user creating an ActionProviderBlueprint to customize
somewhat the authentication process by specifying a (resource server)
named to be used when validating input Globus Auth tokens, and to
specify a set of scopes which are also considered valid for all
operations via a Blueprint.