### PR TITLE
Updates and documents testing tools

### DIFF
--- a/docs/source/toolkit.rst
+++ b/docs/source/toolkit.rst
@@ -23,8 +23,12 @@ defined in 3. For those users building an Action Provider using Flask, this
 provides a simplified method of getting the REST API implemented and removing
 common requirements so the focus can be on the logic of the Action provided.
 
-5. 
-:doc:`Caching guide <toolkit/caching>` 
+5. :doc:`Caching guide <toolkit/caching>` for tweaking the performance of Action
+Providers with relation to Globus Auth.
+
+6. :doc:`Testing tools <toolkit/testing>` provides various resources for
+stubbing Authentication out of an Action Provider and providing a simple way of
+validating an Action Provider's behavior.
 
 .. toctree::
    :maxdepth: 1
@@ -35,3 +39,4 @@ common requirements so the focus can be on the logic of the Action provided.
    toolkit/data_types
    toolkit/flask_helpers
    toolkit/validation
+   toolkit/testing

--- a/docs/source/toolkit/testing.rst
+++ b/docs/source/toolkit/testing.rst
@@ -1,0 +1,213 @@
+Testing
+=======
+
+An Action Provider is closely tightle with Globus Auth (see
+:ref:`globus_auth_setup`). This integration makes it easy to validate incoming
+requests and ensures that the requestor is authorized to execute actions against
+an Action Provider. However, the integration can make it difficult to run tests
+against an Action Provider to validate that its endpoints behave correctly.
+During a CI/CD pipeline, it may be desirable to start your Action Provider
+without a valid Client ID or Secret just to make sure that the app behaves
+correctly.
+
+The toolkit provides various tools to enable testing and validation in the
+:code:`globus_action_provider_tools.testing` module.
+
+
+Fixtures
+^^^^^^^^
+
+The toolkit provides various `pytest fixtures
+<https://docs.pytest.org/en/stable/fixture.html>`_  that greatly reduce the need
+to manually mock and patch interactions with Globus Auth. If an Action Provider
+is created using any of the Flask helpers provided in the
+:code:`globus_action_provider_tools.flask` module, we provide a fixture to
+easily mock authentication out of your Action Provider. Each of the Flask
+helpers internally creates a *TokenChecker* which does two things: it validates
+that the Action Provider is correctly configured with a valid Globus Auth Client
+ID and Secret, and it validates that incoming requests contain a valid token.
+These fixtures abstract both aspects of the internal *TokenChecker* so that you
+can focus on testing your Action Provider's behavior and logic. 
+
+
+Action Provider Blueprint
+-------------------------
+
+If your Action Provider is built using the *ActionProviderBlueprint* Flask
+helper, use the :code:`apt_blueprint_noauth` fixture in
+:code:`globus_action_provider_tools.testing.fixtures`:
+
+.. code-block:: python
+                
+    from globus_action_provider_tools.testing.fixtures import (
+        apt_blueprint_noauth
+    )
+
+Once imported, it can be used just as any other pytest fixture. We recommend
+passing it as a parameter to another fixture which ultimately creates the app
+and returns a resource for use in tests. Provide the fixture your
+*ActionProviderBlueprint* instance under test. This will update your instance
+with stubbed out authentication. The example below shows how to create a
+:code:`client` fixture which can be used to make unauthenticated HTTP requests
+against the Action Provider:
+
+.. code-block:: python
+
+    from myapp import action_provider_blueprint
+
+    @pytest.fixture(scope="module")
+    def client(apt_blueprint_noauth):
+        apt_blueprint_noauth(action_provider_blueprint)
+        app = create_app()
+        return app.test_client()
+
+Once composed like this, you can use the :code:`client` fixture in your tests to
+receive and use a Flask *test_client* to make unauthenticated requests against
+your Action Provider:
+
+.. code-block:: python
+
+    def test_introspection_endpoint(client):
+        response = client.get("/")
+        assert response.status_code == 200
+
+
+Flask API Helpers
+-----------------
+
+If your Action Provider is built using the
+:code:`add_action_routes_to_blueprint` Flask helper, use the
+:code:`flask_helpers_noauth` fixture in
+:code:`globus_action_provider_tools.testing.fixtures*`:
+
+.. code-block:: python
+                
+    from globus_action_provider_tools.testing.fixtures import (
+        flask_helpers_noauth
+    )
+
+Once imported, simply pass the :code:`flask_helpers_noauth` fixture as a
+parameter to another fixture which creates the app and returns a resource for
+use in tests. Unlike the :code:`apt_blueprint_noauth` fixture, the
+:code:`flask_helpers_noauth` fixture does not need to be explicitly executed -
+simply passing it as a parameter is sufficient to temporarily stub out the
+Provider's authentication. An example of how to create a :code:`client` fixture
+which can be used to make unauthenticated HTTP requests against the Action
+Provider is shown below:
+
+.. code-block:: python
+
+    @pytest.fixture(scope="module")
+    def client(flask_helpers_noauth):
+        app = create_app()
+        app.config["TESTING"] = True
+        yield app.test_client()
+
+Once composed like this, you can use the :code:`client` fixture in your tests to
+receive and use a Flask *test_client* to make requests against your Action
+Provider:
+
+.. code-block:: python
+
+    def test_introspection_endpoint(client):
+        response = client.get("/")
+        assert response.status_code == 200
+
+.. note:: 
+    
+    The :code:`flask_helpers_noauth` fixture will patch the TokenChecker in a
+    global scope during testing, meaning that any other Action Providers that
+    are themselves built using the Flask API Helpers will also have their
+    TokenChecker's patched. This may lead to unintended issues if testing
+    multiple Action Providers in the same pytest test session. If this is your
+    case, we highly recommend isolating your Action Provider tests.
+
+
+Mocks
+^^^^^
+
+The toolkit provides various `mocks
+<https://docs.python.org/3/library/unittest.mock.html#the-mock-class>`_ which
+can be used individually to stub out your Action Provider's authentication. You
+should use these directly if you are writing an Action Provider using a
+non-Flask framework or if you've decided not to use the built in Flask helpers.
+
+.. note::
+
+    This toolkit uses these mocks within the
+    :code:`globus_action_provider_tools.testing.fixtures` module.  
+
+
+.. _mock-authstate:
+
+Mock AuthState
+--------------
+
+An *AuthState* represents a requestor's authentication status and Globus Auth
+information. Every request should have its token validated via the
+*TokenChecker*'s :code:`check_token` method, which in turns generates an
+*AuthState* object.
+
+During testing, it is desirable to not need to provide valid tokens with every
+request. Use the :code:`mock_authstate` mock to generate a stubbed out
+*AuthState* object that won't validate requestor properties against Globus Auth.
+This is most useful when used in a patch as the return value for the
+*TokenChecker*'s :code:`check_token` method:
+
+.. code-block:: python
+
+    from unittest import mock     
+
+    import pytest
+    from globus_action_provider_tools.testing.mocks import mock_authstate
+
+    ...
+
+    @pytest.fixture
+    def client():
+        with mock.patch(
+            "globus_action_provider_tools.authentication.TokenChecker.check_token",
+            return_value=mock_authstate(),
+        ):
+            yield app.test_client()
+
+The example above creates a fixture which can be used to create a client that
+can make unauthenticated HTTP requests against an Action Provider. 
+
+
+Mock TokenChecker
+-----------------
+
+Because the *TokenChecker* is this toolkit's authentication workhorse, it's
+possible to entirely replace the the *TokenChecker* with a mock object. Doing so
+will allow your Action Provider to start up without validating its Client ID or
+Secret and will also allow unauthenticated requests to be made against it. This
+mock provides a simple way of completely removing your app's authentication
+during testing.
+
+
+.. code-block:: python
+
+    from unittest import mock
+
+    import pytest
+    from globus_action_provider_tools.testing.mocks import mock_tokenchecker
+
+    @pytest.fixture
+    def client():
+        with mock.patch(
+            "my_package.my_app.get_tokenchecker",
+            return_value=mock_tokenchecker(),
+        ):
+            app = create_app()
+            app.config["TESTING"] = True
+            yield app.test_client()
+
+
+.. note::
+
+    This example will only work if there's a function or method that is used to
+    create the TokenChecker instance. It demonstrates how you can patch a
+    function or a method to return the Mock TokenChecker. Internally, the Mock
+    TokenChecker will generate the :ref:`mock-authstate` objects described
+    above.

--- a/examples/apt_blueprint/tests/test_action_provider.py
+++ b/examples/apt_blueprint/tests/test_action_provider.py
@@ -3,21 +3,19 @@ import uuid
 import pytest
 
 from examples.apt_blueprint.app import create_app
-from examples.apt_blueprint.blueprint import description
+from examples.apt_blueprint.blueprint import aptb, description
 from globus_action_provider_tools.data_types import ActionStatusValue
-from globus_action_provider_tools.testing.patches import (
-    flask_blueprint_tokenchecker_patch,
-)
+from globus_action_provider_tools.testing.fixtures import apt_blueprint_noauth
 
 
 @pytest.fixture(scope="module")
-def client():
-    # Create the app in a patched context so that the Provider can startup
-    # without valid credentials AND requests can be made without supplying a
-    # valid token
-    with flask_blueprint_tokenchecker_patch:
-        app = create_app()
-        yield app.test_client()
+def client(apt_blueprint_noauth):
+    # Patch the blueprint BEFORE attaching it to an app so that the Provider can
+    # start without valid credentials AND requests can be made without supplying
+    # a valid token
+    apt_blueprint_noauth(aptb)
+    app = create_app()
+    return app.test_client()
 
 
 @pytest.fixture(scope="function")

--- a/examples/apt_blueprint/tests/test_action_provider.py
+++ b/examples/apt_blueprint/tests/test_action_provider.py
@@ -15,7 +15,7 @@ def client(apt_blueprint_noauth):
     # a valid token
     apt_blueprint_noauth(aptb)
     app = create_app()
-    return app.test_client()
+    yield app.test_client()
 
 
 @pytest.fixture(scope="function")

--- a/examples/watchasay/tests/test_action_provider.py
+++ b/examples/watchasay/tests/test_action_provider.py
@@ -21,20 +21,17 @@ import pytest
 
 from examples.watchasay.app.provider import create_app, load_schema
 from globus_action_provider_tools.data_types import ActionStatusValue
-from globus_action_provider_tools.testing.patches import (
-    flask_api_helpers_tokenchecker_patch,
-)
+from globus_action_provider_tools.testing.fixtures import flask_helpers_noauth
 
 
 @pytest.fixture(scope="module")
-def client():
-    # Create the app in a patched context so that the Provider can startup
-    # without valid credentials AND requests can be made without supplying a
-    # valid token
-    with flask_api_helpers_tokenchecker_patch:
-        app = create_app()
-        app.config["TESTING"] = True
-        yield app.test_client()
+def client(flask_helpers_noauth):
+    # Patch the app using the flask_helpers_noauth fixture so that the Provider
+    # can start up without valid credentials AND requests can be made without
+    # supplying a valid token
+    app = create_app()
+    app.config["TESTING"] = True
+    yield app.test_client()
 
 
 @pytest.fixture(scope="function")

--- a/examples/whattimeisitrightnow/tests/test_action_provider.py
+++ b/examples/whattimeisitrightnow/tests/test_action_provider.py
@@ -36,15 +36,15 @@ with mock.patch(
 
 
 @pytest.fixture
-def client():
-    with mock.patch(
+def client(monkeypatch):
+    monkeypatch.setattr(
         "globus_action_provider_tools.authentication.TokenChecker.check_token",
-        return_value=mock_authstate(),
-    ):
-        from examples.whattimeisitrightnow.app.app import app
+        mock_authstate,
+    )
+    from examples.whattimeisitrightnow.app.app import app
 
-        app.config["TESTING"] = True
-        yield app.test_client()
+    app.config["TESTING"] = True
+    yield app.test_client()
 
 
 def test_introspection_endpoint(client):

--- a/examples/whattimeisitrightnow/tests/test_action_provider.py
+++ b/examples/whattimeisitrightnow/tests/test_action_provider.py
@@ -31,14 +31,20 @@ from globus_action_provider_tools.testing.mocks import mock_authstate
 with mock.patch(
     "globus_action_provider_tools.authentication.TokenChecker.check_token",
     return_value=mock_authstate(),
-) as patched_check_token:
-    from examples.whattimeisitrightnow.app.app import app, schema
+):
+    from examples.whattimeisitrightnow.app.app import schema
 
 
 @pytest.fixture
 def client():
-    app.config["TESTING"] = True
-    yield app.test_client()
+    with mock.patch(
+        "globus_action_provider_tools.authentication.TokenChecker.check_token",
+        return_value=mock_authstate(),
+    ):
+        from examples.whattimeisitrightnow.app.app import app
+
+        app.config["TESTING"] = True
+        yield app.test_client()
 
 
 def test_introspection_endpoint(client):

--- a/globus_action_provider_tools/testing/fixtures.py
+++ b/globus_action_provider_tools/testing/fixtures.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+
+import pytest
+
+from globus_action_provider_tools.flask.apt_blueprint import ActionProviderBlueprint
+from globus_action_provider_tools.testing.mocks import mock_authstate, mock_tokenchecker
+
+
+@pytest.fixture(scope="module")
+def apt_blueprint_noauth():
+    """
+    A fixture designed to mock an ActionProviderBlueprint instance's Globus
+    Auth integration. The fixture returns a function to which the instance
+    should be supplied as a parameter:
+
+    i.e. apt_blueprint_noauth(aptb)
+    """
+
+    def _apt_blueprint_noauth(aptb: ActionProviderBlueprint):
+        # Manually remove the function that creates the internal token_checker
+        for f in aptb.deferred_functions:
+            if f.__name__ == "_create_token_checker":
+                aptb.deferred_functions.remove(f)
+
+        # Use a mocked token checker internally
+        aptb.checker = mock_tokenchecker()
+
+    return _apt_blueprint_noauth
+
+
+@pytest.fixture(scope="module")
+def flask_helpers_noauth():
+    """
+    A fixture designed to mock the Globus Auth integration in an Flask app
+    created using the api_helpers. Simply using this fixture will allow creating
+    the mocked app.
+    """
+    with patch(
+        "globus_action_provider_tools.flask.api_helpers.TokenChecker.check_token",
+        return_value=mock_authstate(),
+    ):
+        yield

--- a/globus_action_provider_tools/testing/fixtures.py
+++ b/globus_action_provider_tools/testing/fixtures.py
@@ -6,7 +6,7 @@ from globus_action_provider_tools.flask.apt_blueprint import ActionProviderBluep
 from globus_action_provider_tools.testing.mocks import mock_authstate, mock_tokenchecker
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def apt_blueprint_noauth():
     """
     A fixture designed to mock an ActionProviderBlueprint instance's Globus
@@ -28,7 +28,7 @@ def apt_blueprint_noauth():
     return _apt_blueprint_noauth
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def flask_helpers_noauth():
     """
     A fixture designed to mock the Globus Auth integration in an Flask app

--- a/globus_action_provider_tools/testing/mocks.py
+++ b/globus_action_provider_tools/testing/mocks.py
@@ -1,45 +1,41 @@
-from typing import NamedTuple
-from unittest.mock import PropertyMock, patch
+from unittest.mock import Mock
 
 from globus_sdk import ConfidentialAppAuthClient
 
+from globus_action_provider_tools.authentication import TokenChecker
 from globus_action_provider_tools.data_types import AuthState
 
 
-def mock_authstate():
+def mock_authstate(*args, **kwargs):
     """
     Returns a dummy AuthState object with mocked out methods and properties.
     This is particularly useful for mocking out the TokenChecker.check_token
     function. Should only be used for testing because it avoids the need for
     supplying valid CLIENT_IDs, CLIENT_SECRETs, and TOKENs
     """
+    # auth_client = ConfidentialAppAuthClient(None, None)
+    auth_state = Mock(spec=AuthState, name="MockedAPTAuthState")
 
-    def mock_check_authorization(*args, **kwargs):
-        return True
-
-    def mock_primary_identity(*args, **kwargs):
-        return "urn:globus:auth:identity:00000000-0000-0000-0000-000000000000"
-
-    def mock_introspect_token(*args, **kwargs):
-        return None
-
-    auth_client = ConfidentialAppAuthClient(None, None)
-    auth_state = AuthState(auth_client, None, None)
-    auth_state.check_authorization = mock_check_authorization
-    auth_state.primary_identity = mock_primary_identity
-    auth_state.introspect_token = mock_introspect_token
+    # Spec wont create instance variables created in __init__, so manually
+    # create bearer_token
     auth_state.bearer_token = "MOCK_BEARER_TOKEN"
 
-    # This is how you patch object @properties
-    patch(
-        "globus_action_provider_tools.authentication.AuthState.effective_identity",
-        new_callable=PropertyMock,
-        return_value="MOCK_USER",
-    ).start()
-    patch(
-        "globus_action_provider_tools.authentication.AuthState.identities",
-        new_callable=PropertyMock,
-        return_value=frozenset(["MOCK_USER"]),
-    ).start()
+    # Set property mocks
+    auth_state.effective_identity = "MOCK_USER"
+    auth_state.identities = frozenset(["MOCK_USER"])
+
+    # Mock other functions that get called
+    auth_state.check_authorization.return_value = True
+    auth_state.introspect_token.return_value = None
 
     return auth_state
+
+
+def mock_tokenchecker(*args, **kwargs):
+    """
+    Returns a dummy TokenChecker object with a mocked out check_token method.
+    In turn, this mock can only produce mocked_authstates.
+    """
+    tokenchecker = Mock(spec=TokenChecker, name="MockedAPTTokenChecker")
+    tokenchecker.check_token.return_value = mock_authstate()
+    return tokenchecker

--- a/globus_action_provider_tools/testing/patches.py
+++ b/globus_action_provider_tools/testing/patches.py
@@ -1,6 +1,18 @@
+import warnings
 from unittest.mock import patch
 
 from globus_action_provider_tools.testing.mocks import mock_authstate
+
+warnings.warn(
+    (
+        "The globus_action_provider_tools.testing.patches module is deprecated. "
+        "Please consider using the globus_action_provider_tools.testing.fixtures "
+        "module instead."
+    ),
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 flask_api_helpers_tokenchecker_patch = patch(
     "globus_action_provider_tools.flask.api_helpers.TokenChecker.check_token",

--- a/tests/test_mocks.py
+++ b/tests/test_mocks.py
@@ -1,28 +1,47 @@
 from unittest import mock
 
+import pytest
+
 from globus_action_provider_tools.authentication import TokenChecker
 from globus_action_provider_tools.data_types import AuthState
-from globus_action_provider_tools.testing.mocks import mock_authstate
+from globus_action_provider_tools.testing.mocks import mock_authstate, mock_tokenchecker
 
 
 def test_create_mocked_tokenchecker():
-    with mock.patch(
-        "globus_action_provider_tools.authentication.TokenChecker.check_token",
-        return_value=mock_authstate(),
-    ):
-        tc = TokenChecker(None, None, [None])
+    tc = mock_tokenchecker("", "not_a_secret", bogus_kwarg="sure")
 
-        assert tc is not None
-        assert isinstance(tc, TokenChecker)
+    assert tc is not None
+    assert isinstance(tc, TokenChecker)
 
 
 def test_mocked_tokenchecker_checks_token():
-    with mock.patch(
-        "globus_action_provider_tools.authentication.TokenChecker.check_token",
-        return_value=mock_authstate(),
-    ):
-        tc = TokenChecker(None, None, [None])
-        authstate = tc.check_token(None)
+    auth = mock_tokenchecker().check_token(None)
 
-        assert authstate is not None
-        assert isinstance(authstate, AuthState)
+    assert auth is not None
+    assert isinstance(auth, AuthState)
+
+
+def test_tokenchecker_is_specced():
+    tc = mock_tokenchecker()
+    with pytest.raises(AttributeError):
+        tc.not_a_valid_method()
+
+
+def test_create_mocked_authstate():
+    auth = mock_authstate("", "not_a_secret", bogus_kwarg="sure")
+
+    assert auth is not None
+    assert isinstance(auth, AuthState)
+
+
+def test_authstate_is_specced():
+    authstate = mock_authstate()
+    with pytest.raises(AttributeError):
+        authstate.not_a_valid_method()
+
+
+def test_mocked_tokenchecker_creates_mocked_authstate():
+    assert (
+        mock_authstate().effective_identity
+        == mock_tokenchecker().check_token().effective_identity
+    )


### PR DESCRIPTION
Improves the state of testing tools in ActionProviderTools. The `mocks.py` module is greatly slimmed down and provides a new `TokenChecker` mock which can be used to replace `TokenChecker` instances.  The addition of `fixtures.py` introduces fixtures that mock Globus Auth integration for the two Flask toolk, APTBlueprint and Flask Helpers.

Examples are updated to demonstrate using the fixtures to test apps without a Globus Auth Client ID, secret, or token.

Docs are updated with to reflect the new fixtures and updated mocks as well as with information on when/how to use each fixture and when to use the mocks instead.

Adds a deprecation warning to the testing patches, mostly because the `flask_blueprint_tokenchecker_patch` is not as good as the `apt_blueprint_noauth` fixture (the fixture mocks only the blueprint-under-test's TokenChecker whereas the patch mocks the TokenChecker globally for all blueprint's.). Also the `flask_api_helpers_tokenchecker_patch` is effectively the same as the `flask_helpers_noauth` fixture, except in both cases the fixtures are more convenient and easier to work with.

Adds tests validating the new mocks. "Dogfoods" the new fixtures by using them in the toolkit test's for the Flask helpers.