### PR TITLE
Only runs pipeline when releases are created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: PyPi Publish
 
 on:
   release:
-    types: [created, edited]
+    types:
+      - created
 
 jobs:
   publish:


### PR DESCRIPTION
Fixes the release pipeline so that it only runs when new releases are created.  This makes sense because PyPi doesn't allow pushing the same package using the same release version, enforcing that releases are immutable. 