### PR TITLE
Implements standardized ActionProvider exceptions

### DIFF
--- a/examples/apt_blueprint/tests/test_action_provider.py
+++ b/examples/apt_blueprint/tests/test_action_provider.py
@@ -49,21 +49,21 @@ def test_run_endpoint(client):
     response = client.post("/apt/run", json=data)
 
     assert response.status_code == 202
-    assert response.json["status"] == ActionStatusValue.ACTIVE.name
+    assert response.json["status"] == ActionStatusValue.ACTIVE
 
 
 def test_status_endpoint(client, running_action_id):
     response = client.get(f"/apt/{running_action_id}/status")
 
     assert response.status_code == 200
-    assert response.json["status"] == ActionStatusValue.ACTIVE.name
+    assert response.json["status"] == ActionStatusValue.ACTIVE
 
 
 def test_cancel_endpoint(client, running_action_id):
     response = client.post(f"/apt/{running_action_id}/cancel")
 
     assert response.status_code == 200
-    assert response.json["status"] == ActionStatusValue.FAILED.name
+    assert response.json["status"] == ActionStatusValue.FAILED
 
 
 def test_release_endpoint(client, running_action_id):
@@ -72,4 +72,4 @@ def test_release_endpoint(client, running_action_id):
     response = client.post(f"/apt/{running_action_id}/release")
 
     assert response.status_code == 200
-    assert response.json["status"] == ActionStatusValue.FAILED.name
+    assert response.json["status"] == ActionStatusValue.FAILED

--- a/examples/watchasay/tests/test_action_provider.py
+++ b/examples/watchasay/tests/test_action_provider.py
@@ -66,14 +66,14 @@ def test_run_endpoint(client):
     response = client.post("/skeleton/run", json=data)
 
     assert response.status_code == 202
-    assert response.json["status"] == ActionStatusValue.SUCCEEDED.name
+    assert response.json["status"] == ActionStatusValue.SUCCEEDED
 
 
 def test_status_endpoint(client, running_action_id):
     response = client.get(f"/skeleton/{running_action_id}/status")
 
     assert response.status_code == 200
-    assert response.json["status"] == ActionStatusValue.SUCCEEDED.name
+    assert response.json["status"] == ActionStatusValue.SUCCEEDED
 
 
 def test_cancel_endpoint(client, running_action_id):
@@ -81,7 +81,7 @@ def test_cancel_endpoint(client, running_action_id):
     response = client.post(f"/skeleton/{running_action_id}/cancel")
 
     assert response.status_code == 200
-    assert response.json["status"] == ActionStatusValue.SUCCEEDED.name
+    assert response.json["status"] == ActionStatusValue.SUCCEEDED
 
 
 def test_release_endpoint(client, running_action_id):
@@ -89,4 +89,4 @@ def test_release_endpoint(client, running_action_id):
     response = client.post(f"/skeleton/{running_action_id}/release")
 
     assert response.status_code == 200
-    assert response.json["status"] == ActionStatusValue.SUCCEEDED.name
+    assert response.json["status"] == ActionStatusValue.SUCCEEDED

--- a/examples/whattimeisitrightnow/app/app.py
+++ b/examples/whattimeisitrightnow/app/app.py
@@ -169,7 +169,7 @@ def run_action(req) -> ActionStatus:
         start_time=str(now),
         completion_time=None,
         release_after=req.get("release_after", "P30D"),
-        display_status=ActionStatusValue.ACTIVE.name,
+        display_status=ActionStatusValue.ACTIVE,
         details=results,
     )
 
@@ -300,10 +300,10 @@ def _reconcile_action_status(action_status: ActionStatus) -> ActionStatus:
 
     if private["success"]:
         action_status.status = ActionStatusValue.SUCCEEDED
-        action_status.display_status = ActionStatusValue.SUCCEEDED.name
+        action_status.display_status = ActionStatusValue.SUCCEEDED
     else:
         action_status.status = ActionStatusValue.FAILED
-        action_status.display_status = ActionStatusValue.FAILED.name
+        action_status.display_status = ActionStatusValue.FAILED
 
     # Persist updates to the ActionStatus
     db.persist(action_status.action_id, action_status)

--- a/examples/whattimeisitrightnow/tests/test_action_provider.py
+++ b/examples/whattimeisitrightnow/tests/test_action_provider.py
@@ -60,7 +60,7 @@ def test_run_endpoint(client):
     response = client.post("/run", data=json.dumps(data))
 
     assert response.status_code == 202
-    assert json.loads(response.data)["status"] == ActionStatusValue.ACTIVE.name
+    assert json.loads(response.data)["status"] == ActionStatusValue.ACTIVE
 
 
 def test_status_endpoint(client):
@@ -71,7 +71,7 @@ def test_status_endpoint(client):
     response = client.get(f"/{action_id}/status")
 
     assert response.status_code == 200
-    assert json.loads(response.data)["status"] == ActionStatusValue.ACTIVE.name
+    assert json.loads(response.data)["status"] == ActionStatusValue.ACTIVE
 
 
 def test_cancel_endpoint(client):
@@ -82,7 +82,7 @@ def test_cancel_endpoint(client):
     response = client.post(f"/{action_id}/cancel")
 
     assert response.status_code == 200
-    assert json.loads(response.data)["status"] == ActionStatusValue.FAILED.name
+    assert json.loads(response.data)["status"] == ActionStatusValue.FAILED
 
     # Try re-cancelling the same action, expecting an error to occur
     response = client.post(f"/{action_id}/cancel")
@@ -104,4 +104,4 @@ def test_release_endpoint(client):
     response = client.post(f"/{action_id}/release")
 
     assert response.status_code == 200
-    assert json.loads(response.data)["status"] == ActionStatusValue.FAILED.name
+    assert json.loads(response.data)["status"] == ActionStatusValue.FAILED

--- a/globus_action_provider_tools/authorization.py
+++ b/globus_action_provider_tools/authorization.py
@@ -1,6 +1,6 @@
 from itertools import chain
 
-from werkzeug.exceptions import NotFound
+from globus_action_provider_tools.exceptions import ActionNotFound
 
 from .authentication import AuthState
 from .data_types import ActionStatus
@@ -21,7 +21,7 @@ def authorize_action_access_or_404(status: ActionStatus, auth_state: AuthState) 
         allowed_set, allow_all_authenticated_users=True
     )
     if not authorized:
-        raise NotFound(f"No Action with id {status.action_id}")
+        raise ActionNotFound(f"No Action with id {status.action_id}")
 
 
 def authorize_action_management_or_404(
@@ -41,4 +41,4 @@ def authorize_action_management_or_404(
         allowed_set, allow_all_authenticated_users=True
     )
     if not authorized:
-        raise NotFound(f"No Action with id {status.action_id}")
+        raise ActionNotFound(f"No Action with id {status.action_id}")

--- a/globus_action_provider_tools/data_types.py
+++ b/globus_action_provider_tools/data_types.py
@@ -3,7 +3,18 @@ from dataclasses import asdict, dataclass, field, is_dataclass
 from enum import Enum, auto
 from json import JSONEncoder
 from os import urandom
-from typing import AbstractSet, Any, Dict, Iterable, List, NamedTuple, Optional, Union
+from typing import (
+    AbstractSet,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Type,
+    Union,
+)
 
 import arrow
 from base62 import encodebytes as base62
@@ -22,17 +33,35 @@ def shortish_id() -> str:
     return base62(urandom(9))
 
 
-class ProviderType(Enum):
-    Action = auto()
-    Event = auto()
+class AutomateBaseEnum(str, Enum):
+    """
+    A pythonic Enum class implementation that removes the need to access a
+    "value" attribute to get an Enum's representation.
+    http://www.cosmicpython.com/blog/2020-10-27-i-hate-enums.html
+    """
+
+    def __str__(self) -> str:
+        return str.__str__(self)
 
 
-class EventType(Enum):
-    STARTED = auto()
-    STATUS_UPDATE = auto()
-    LOG_UPDATE = auto()
-    COMPLETED = auto()
-    FAILED = auto()
+class ProviderType(AutomateBaseEnum):
+    Action = "ACTION"
+    Event = "EVENT"
+
+
+class EventType(AutomateBaseEnum):
+    STARTED = "STARTED"
+    STATUS_UPDATE = "STATUS_UPDATE"
+    LOG_UPDATE = "LOG_UPDATE"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+
+
+class ActionStatusValue(AutomateBaseEnum):
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    ACTIVE = "ACTIVE"
+    INACTIVE = "INACTIVE"
 
 
 @dataclass
@@ -65,13 +94,6 @@ class ActionRequest:
     allowed_clients: Optional[List[str]] = None
     deadline: Optional[str] = None
     release_after: Optional[str] = None
-
-
-class ActionStatusValue(Enum):
-    SUCCEEDED = auto()
-    FAILED = auto()
-    ACTIVE = auto()
-    INACTIVE = auto()
 
 
 @dataclass

--- a/globus_action_provider_tools/exceptions.py
+++ b/globus_action_provider_tools/exceptions.py
@@ -1,0 +1,76 @@
+"""
+exceptions.py contains JSON-able HTTP exceptions based off the werkzeug
+HTTPException class. These custom exceptions produce a JSON response containing
+error name, http status code, and a description of the issue. 
+
+These exceptions can be raised with a default message directly from werkzeug:
+    raise ActionProviderToolsException
+
+or a custom error message can be supplied:
+    raise ActionNotFound("User unauthorized to run Action")
+"""
+
+import json
+import typing as t
+
+from werkzeug.exceptions import (
+    BadRequest,
+    Conflict,
+    HTTPException,
+    InternalServerError,
+    NotFound,
+    Unauthorized,
+)
+
+JSONType = t.Union[str, int, float, bool, None, t.Dict[str, t.Any], t.List[t.Any]]
+
+
+class ActionProviderToolsException(HTTPException):
+    # This is only required to update allow mypy to recognize the description
+    # can be any JSON-able structure
+    def __init__(self, description: t.Optional[JSONType] = None, *args, **kwargs):
+        if description is not None:
+            description = json.dumps(description)
+        super().__init__(description, *args, **kwargs)
+
+    @property
+    def name(self):
+        return type(self).__name__
+
+    def get_body(self, *args):
+        return json.dumps(
+            {
+                "error": self.name,
+                "status_code": self.code,
+                "description": self.get_description(),
+            }
+        )
+
+    def get_headers(self, *args):
+        return [("Content-Type", "application/json")]
+
+    def get_description(self, *args):
+        try:
+            return json.loads(self.description)
+        except json.decoder.JSONDecodeError:
+            return self.description
+
+
+class ActionNotFound(ActionProviderToolsException, NotFound):
+    pass
+
+
+class BadActionRequest(BadRequest, ActionProviderToolsException):
+    pass
+
+
+class ActionConflict(ActionProviderToolsException, Conflict):
+    pass
+
+
+class UnauthorizedRequest(ActionProviderToolsException, Unauthorized):
+    pass
+
+
+class ActionProviderError(ActionProviderToolsException, InternalServerError):
+    pass

--- a/globus_action_provider_tools/flask/types.py
+++ b/globus_action_provider_tools/flask/types.py
@@ -1,0 +1,25 @@
+from typing import Any, Callable, Dict, Sequence, Set, Tuple, Union
+
+from flask import Response
+
+from globus_action_provider_tools.data_types import (
+    ActionRequest,
+    ActionStatus,
+    AuthState,
+)
+
+ActionStatusReturn = Union[ActionStatus, Tuple[ActionStatus, int]]
+ActionStatusType = Callable[[Union[str, ActionStatus], AuthState], ActionStatusReturn]
+
+ActionLogReturn = Dict[str, Any]
+ActionLogType = Callable[[str, AuthState], ActionLogReturn]
+
+ActionRunType = Callable[[ActionRequest, AuthState], ActionStatusReturn]
+ActionCancelType = ActionStatusType
+ActionReleaseType = ActionStatusType
+ActionEnumerationType = Callable[[AuthState, Dict[str, Set]], Sequence[ActionStatus]]
+
+ViewReturn = Union[Tuple[Response, int], Tuple[str, int]]
+
+ActionLoaderType = Tuple[Callable[[str, Any], ActionStatus], Any]
+ActionSaverType = Tuple[Callable[[ActionStatus, Any], None], Any]

--- a/globus_action_provider_tools/testing/mocks.py
+++ b/globus_action_provider_tools/testing/mocks.py
@@ -21,8 +21,10 @@ def mock_authstate(*args, **kwargs):
     auth_state.bearer_token = "MOCK_BEARER_TOKEN"
 
     # Set property mocks
-    auth_state.effective_identity = "MOCK_USER"
-    auth_state.identities = frozenset(["MOCK_USER"])
+    auth_state.effective_identity = (
+        "urn:globus:auth:identity:00000000-0000-0000-0000-000000000000"
+    )
+    auth_state.identities = frozenset([auth_state.effective_identity])
 
     # Mock other functions that get called
     auth_state.check_authorization.return_value = True

--- a/globus_action_provider_tools/validation.py
+++ b/globus_action_provider_tools/validation.py
@@ -43,9 +43,8 @@ response_validator = request_validator
 
 
 def validate_data(data: Dict[str, Any], validator: Draft7Validator) -> ValidationResult:
-    errors = validator.iter_errors(data)
     error_messages = []
-    for error in errors:
+    for error in validator.iter_errors(data):
         if error.path:
             # Elements of the error path may be integers or other non-string types,
             # but we need strings for use with join()

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -7,10 +7,10 @@ from globus_sdk.response import GlobusHTTPResponse
 from globus_action_provider_tools.authentication import (
     GROUPS_SCOPE,
     AuthState,
-    ConfigurationError,
     TokenChecker,
     identity_principal,
 )
+from globus_action_provider_tools.exceptions import ActionProviderError
 from globus_action_provider_tools.groups_client import GroupsClient
 
 from .data import canned_responses
@@ -45,7 +45,7 @@ def bad_credentials_error(live_api, monkeypatch):
 
 
 def test_token_checker_bad_credentials():
-    with pytest.raises(ConfigurationError):
+    with pytest.raises(ActionProviderError):
         TokenChecker(
             client_id="bogus",
             client_secret="bogus",

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,25 +1,25 @@
 import datetime
 
 import pytest
-from werkzeug.exceptions import NotFound
 
 from globus_action_provider_tools.authorization import (
     authorize_action_access_or_404,
     authorize_action_management_or_404,
 )
 from globus_action_provider_tools.data_types import ActionStatus, ActionStatusValue
+from globus_action_provider_tools.exceptions import ActionNotFound
+
+from .utils import random_creator_id
 
 
 def test_creator_can_access(auth_state):
     status = ActionStatus(
-        status=ActionStatusValue.SUCCEEDED.name,
+        status=ActionStatusValue.SUCCEEDED,
         creator_id=auth_state.effective_identity,
-        monitor_by=None,
-        manage_by=None,
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
         release_after="P30D",
-        display_status=ActionStatusValue.SUCCEEDED.name,
+        display_status=ActionStatusValue.SUCCEEDED,
         details={},
     )
 
@@ -28,14 +28,13 @@ def test_creator_can_access(auth_state):
 
 def test_monitor_by_can_access(auth_state):
     status = ActionStatus(
-        status=ActionStatusValue.SUCCEEDED.name,
-        creator_id="",
+        status=ActionStatusValue.SUCCEEDED,
+        creator_id=auth_state.effective_identity,
         monitor_by=[auth_state.effective_identity],
-        manage_by=None,
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
         release_after="P30D",
-        display_status=ActionStatusValue.SUCCEEDED.name,
+        display_status=ActionStatusValue.SUCCEEDED,
         details={},
     )
 
@@ -44,31 +43,27 @@ def test_monitor_by_can_access(auth_state):
 
 def test_unauthorized_access(auth_state):
     status = ActionStatus(
-        status=ActionStatusValue.SUCCEEDED.name,
-        creator_id="",
-        monitor_by=None,
-        manage_by=None,
+        status=ActionStatusValue.SUCCEEDED,
+        creator_id=random_creator_id(),
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
         release_after="P30D",
-        display_status=ActionStatusValue.SUCCEEDED.name,
+        display_status=ActionStatusValue.SUCCEEDED,
         details={},
     )
 
-    with pytest.raises(NotFound):
+    with pytest.raises(ActionNotFound):
         authorize_action_access_or_404(status, auth_state)
 
 
 def test_creator_can_manage(auth_state):
     status = ActionStatus(
-        status=ActionStatusValue.SUCCEEDED.name,
+        status=ActionStatusValue.SUCCEEDED,
         creator_id=auth_state.effective_identity,
-        monitor_by=None,
-        manage_by=None,
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
         release_after="P30D",
-        display_status=ActionStatusValue.SUCCEEDED.name,
+        display_status=ActionStatusValue.SUCCEEDED,
         details={},
     )
 
@@ -77,14 +72,13 @@ def test_creator_can_manage(auth_state):
 
 def test_manage_by_can_access(auth_state):
     status = ActionStatus(
-        status=ActionStatusValue.SUCCEEDED.name,
-        creator_id="",
-        monitor_by="",
+        status=ActionStatusValue.SUCCEEDED,
+        creator_id=random_creator_id(),
         manage_by=[auth_state.effective_identity],
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
         release_after="P30D",
-        display_status=ActionStatusValue.SUCCEEDED.name,
+        display_status=ActionStatusValue.SUCCEEDED,
         details={},
     )
 
@@ -93,16 +87,14 @@ def test_manage_by_can_access(auth_state):
 
 def test_unauthorized_management(auth_state):
     status = ActionStatus(
-        status=ActionStatusValue.SUCCEEDED.name,
-        creator_id="",
-        monitor_by=None,
-        manage_by=None,
+        status=ActionStatusValue.SUCCEEDED,
+        creator_id=random_creator_id(),
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
         release_after="P30D",
-        display_status=ActionStatusValue.SUCCEEDED.name,
+        display_status=ActionStatusValue.SUCCEEDED,
         details={},
     )
 
-    with pytest.raises(NotFound):
+    with pytest.raises(ActionNotFound):
         authorize_action_management_or_404(status, auth_state)

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -9,22 +9,24 @@ from globus_action_provider_tools.data_types import (
     ActionStatusValue,
 )
 
+from .utils import random_creator_id
+
 
 def test_action_status_jsonable():
     action_status = ActionStatus(
         status=ActionStatusValue.SUCCEEDED,
-        creator_id=None,
-        monitor_by=None,
+        creator_id=random_creator_id(),
+        monitor_by=[],
         manage_by=set(),
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
         release_after="P30D",
-        display_status=ActionStatusValue.SUCCEEDED.name,
+        display_status=ActionStatusValue.SUCCEEDED,
         details={},
     )
     try:
         # This will fail if ActionProviderJsonEncoder cannot json dump an
         # ActionStatus
         json.dumps(action_status, cls=ActionProviderJsonEncoder)
-    except TypeError:
-        pytest.fail("Unexpected JSON encoding error")
+    except TypeError as e:
+        pytest.fail(f"Unexpected JSON encoding error: {e}")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,37 @@
+import json
+
+import pytest
+
+from globus_action_provider_tools.exceptions import (
+    ActionConflict,
+    ActionNotFound,
+    ActionProviderError,
+    BadActionRequest,
+    UnauthorizedRequest,
+)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ActionConflict,
+        ActionNotFound,
+        ActionProviderError,
+        BadActionRequest,
+        UnauthorizedRequest,
+    ],
+)
+def test_exceptions(exc):
+    # Validate that all exceptions are JSON-able and contain status_code, error,
+    # and description fields
+
+    with pytest.raises(exc) as exc_info:
+        raise exc
+
+    data = exc_info.value.get_response().get_data()
+    data = json.loads(data)
+
+    assert "error" in data
+    assert data["error"] == exc.__name__
+    assert "status_code" in data
+    assert "description" in data

--- a/tests/test_flask_helpers/conftest.py
+++ b/tests/test_flask_helpers/conftest.py
@@ -5,8 +5,6 @@ the only difference being in the helper that is used to create the app.
 """
 
 
-from unittest.mock import patch
-
 import pytest
 from flask import Blueprint, Flask
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,5 @@
+import uuid
+
+
+def random_creator_id():
+    return "urn:globus:auth:identity:" + str(uuid.uuid4())


### PR DESCRIPTION
Adds werkzeug-based HTTP exceptions that can be raised to return JSON error results containing http status code, error name, and error description. The error description can be customized by the user.

Subclasses the built in `str` class in our enum classes to allow string comparisons to our enum classes to succeed without the need to access the `.value` attribute.

Also refactors the Flask helpers to improve shared methods and types between the two Flask helper tools.