### PR TITLE
Updates ActionStatus details field type

### DIFF
--- a/examples/whattimeisitrightnow/app/app.py
+++ b/examples/whattimeisitrightnow/app/app.py
@@ -173,6 +173,7 @@ def _filter_private_fields(action_status: ActionStatus) -> ActionStatus:
     data before returning an ActionStatus to the requestor
     """
     if action_status.details is not None:
+        assert isinstance(action_status.details, dict)
         action_status.details.pop("private", None)
     return action_status
 
@@ -274,11 +275,13 @@ def _reconcile_action_status(action_status: ActionStatus) -> ActionStatus:
 
     # If it is not yet time for the action to complete, return
     now = datetime.now(tz=timezone.utc)
+    assert isinstance(action_status.details, dict)
     if action_status.details["estimated_completion_time"] > now:
         return action_status
 
     # If the action was scheduled to complete by now, update the ActionStatus
     # object with completion data
+    assert isinstance(action_status.details, dict)
     private = action_status.details.pop("private", {})
     action_status.completion_time = action_status.details["estimated_completion_time"]
     action_status.details = private["details"]

--- a/globus_action_provider_tools/data_types.py
+++ b/globus_action_provider_tools/data_types.py
@@ -270,7 +270,7 @@ class ActionStatus(BaseModel):
         min_length=1,
         max_length=64,
     )
-    details: Union[ActionInactiveDetails, ActionFailedDetails, Dict[str, Any]] = Field(
+    details: Union[ExtensibleCodeDescription, Dict[str, Any], str] = Field(
         ...,
         description=(
             "A provider-specific object representing the full state of the "


### PR DESCRIPTION
Allows ActionStatuses to be created with str type details fields. This PR also updates the allowed types for details to be ExtensibleCodeDescription type, which means that an instance of any subclass of it will be a valid value. The prior implementation would only coerce ActionFailedDetails to ActionInactiveDetails and add empty required_scope and resolution_url fields.