### PR TITLE
Outputs standard formatting for datetimes

### DIFF
--- a/examples/apt_blueprint/blueprint.py
+++ b/examples/apt_blueprint/blueprint.py
@@ -112,7 +112,7 @@ def my_action_run(action_request: ActionRequest, auth: AuthState) -> ActionStatu
         label=action_request.label or None,
         monitor_by=action_request.monitor_by or auth.identities,
         manage_by=action_request.manage_by or auth.identities,
-        start_time=str(datetime.now(tz=timezone.utc)),
+        start_time=datetime.now(timezone.utc).isoformat(),
         completion_time=None,
         release_after=action_request.release_after or "P30D",
         display_status=ActionStatusValue.ACTIVE,

--- a/globus_action_provider_tools/data_types.py
+++ b/globus_action_provider_tools/data_types.py
@@ -14,7 +14,7 @@ from globus_action_provider_tools.authentication import AuthState
 
 
 def now_isoformat():
-    return str(arrow.get().datetime)
+    return str(arrow.utcnow())
 
 
 def shortish_id() -> str:
@@ -296,7 +296,7 @@ class ActionProviderJsonEncoder(JSONEncoder):
         elif inspect.isclass(obj) and issubclass(obj, BaseModel):
             return obj.schema()
         elif isinstance(obj, datetime.datetime):
-            return str(obj)
+            return obj.isoformat()
         elif isinstance(obj, datetime.timedelta):
             return isodate.duration_isoformat(obj)
         return super(ActionProviderJsonEncoder, self).default(obj)


### PR DESCRIPTION
Users were noticing that on an `ActionStatus`, `start_time` and `completion_time` had slightly different ISO8601 formats. `start_time` would look like "2021-04-16T20:15:34.365355+00:00" and `completion_time` would look like "2021-04-16 20:15:34.365355". This was happening because when APT attempted to serialize datetime fields on the `ActionStatus`, it was just casting it using `str()`, which removed some of the extra formatting (timezone information and the 'T'). This fix uses the isoformat() to convert whatever datetime was provided into the uniform isoformat().

If the user creates a field that is ISO8601 compliant but does not contain time zone information, the dumped timestamp will necessarily look different (no timezone info).