### PR TITLE
Fixes return type for action resume

### DIFF
--- a/globus_action_provider_tools/flask/apt_blueprint.py
+++ b/globus_action_provider_tools/flask/apt_blueprint.py
@@ -294,7 +294,7 @@ class ActionProviderBlueprint(Blueprint):
                 authorize_action_access_or_404(action, g.auth_state)
 
             status = func(action_id, g.auth_state)
-            return jsonify(status), 200
+            return action_status_return_to_view_return(status, 200)
 
         # Add new and old-style AP API endpoints
         self.add_url_rule("/<string:action_id>/resume", None, wrapper, methods=["POST"])


### PR DESCRIPTION
The resume endpoint was only handling return values which were `ActionStatus`, not a tuple of [`ActionStatus`, `returnCode`]. This update allows for the resume endpoint to handle either or. This makes it trivial for an AP implementer to return their own status code when the resume operation is called.