### PR TITLE
Configures GroupsClient via environment variable

### DIFF
--- a/globus_action_provider_tools/groups_client.py
+++ b/globus_action_provider_tools/groups_client.py
@@ -1,3 +1,4 @@
+import os
 from typing import AbstractSet, Any, Dict, List, Optional, Set
 
 from globus_sdk.authorizers import GlobusAuthorizer
@@ -5,15 +6,29 @@ from globus_sdk.base import BaseClient
 from globus_sdk.exc import GlobusAPIError, GlobusError
 from globus_sdk.response import GlobusHTTPResponse
 
+GROUPS_API_ENVIRONMENTS: Dict[str, str] = {
+    "default": "https://groups.api.globus.org",
+    "production": "https://groups.api.globus.org",
+    "preview": "",
+    "sandbox": "https://groups.api.sandbox.globuscs.info",
+    "test": "https://groups.api.test.globuscs.info",
+    "integration": "https://groups.api.integration.globuscs.info",
+    "staging": "https://groups.api.staging.globuscs.info",
+}
+
 
 class GroupsClient(BaseClient):
-    BASE_URL = "https://groups.api.globus.org/v2/groups/my_groups"
-
     def __init__(self, authorizer: GlobusAuthorizer, *args, **kwargs):
+        """
+        The Globus SDK only pulls the service URL from its config if it isn't
+        provided on initialization. So here we'll figure it out for ourselves
+        and set it appropriately.
+        """
+        environment = os.environ.get("GLOBUS_SDK_ENVIRONMENT", "default").lower()
         super().__init__(
-            "groups_client",
+            "groups",
             *args,
-            base_url=GroupsClient.BASE_URL,
+            base_url=GROUPS_API_ENVIRONMENTS[environment],
             authorizer=authorizer,
             **kwargs,
         )
@@ -21,7 +36,7 @@ class GroupsClient(BaseClient):
     def list_groups(
         self, roles: AbstractSet[str] = frozenset(("member", "admin", "manager"))
     ) -> List[Dict[str, Any]]:
-        resp: GlobusHTTPResponse = self.get("")
+        resp: GlobusHTTPResponse = self.get("/v2/groups/my_groups")
         data = resp.data
         groups: List[Dict[str, Any]] = []
         for group in data:


### PR DESCRIPTION
This PR updates our homegrown `GroupsClient` to pull it's BASE_URL from the environment in the same way that the `globus_sdk` pulls its clients' configuration from the the GLOBUS_SDK_ENVIRONMENT environment variable. The `globus_sdk` is a rigid about injecting extra urls into its base config so rather than attempt to hotwire our config into theirs, I opted to emulate the behavior. 