### PR TITLE
Adds more logging around authentication failures

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,5 +120,6 @@ Please follow the steps below when creating a new release of the toolkit:
 Links
 -----
 | Full Documentation: https://action-provider-tools.readthedocs.io
+| Rendered Redoc: https://globus.github.io/action-provider-tools/
 | Source Code: https://github.com/globus/action-provider-tools
 | Release History + Changelog: https://github.com/globus/action-provider-tools/releases

--- a/globus_action_provider_tools/flask/apt_blueprint.py
+++ b/globus_action_provider_tools/flask/apt_blueprint.py
@@ -155,6 +155,7 @@ class ActionProviderBlueprint(Blueprint):
             allow_public=True,
             allow_all_authenticated_users=True,
         ):
+            current_app.logger.info(g.auth_state.errors)
             current_app.logger.info(
                 f"{g.auth_state.effective_identity} is unauthorized to introspect Action Provider"
             )
@@ -175,6 +176,7 @@ class ActionProviderBlueprint(Blueprint):
                 allow_public=True,
                 allow_all_authenticated_users=True,
             ):
+                current_app.logger.info(g.auth_state.errors)
                 current_app.logger.info(
                     f"{g.auth_state.effective_identity} is unauthorized to enumerate "
                     "Actions"
@@ -218,6 +220,7 @@ class ActionProviderBlueprint(Blueprint):
                 self.provider_description.runnable_by,
                 allow_all_authenticated_users=True,
             ):
+                current_app.logger.info(g.auth_state.errors)
                 current_app.logger.info(
                     f"{g.auth_state.effective_identity} is unauthorized to run Action"
                 )


### PR DESCRIPTION
When doing an `introspect`, `enumerate`, or `run` operation, there are many scenarios where authentication may fail. This PR logs the errors encountered on the `AuthState` object to provide more information on why a specific request failed.