### PR TITLE
Add license to output of pip show

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   ]
 
 readme = "README.rst"
+license = "Apache-2.0"
 
 [tool.poetry.scripts]
 whattimeisit-provider = "examples.flask.whattimeisitrightnow.app.app:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ name = "globus-action-provider-tools"
 version = "0.11.3"
 description = "Tools to help developers build services that implement the Action Provider specification."
 authors = [
-    "Jim Pruyne <pruyne@globus.org>",
     "Uriel Mandujano <uriel@globus.org>",
+    "Jim Pruyne <pruyne@globus.org>"
 ]
 keywords = [
   "globus",


### PR DESCRIPTION
This PR adds license info to the output of the `pip show globus_action_provider_tools` command:

Before:
```
Name: globus-action-provider-tools
Version: 0.11.2
Summary: Tools to help developers build services that implement the Action Provider specification.
Home-page: None
Author: Jim Pruyne
Author-email: pruyne@globus.org
License: None
Location: /Users/uriel/Projects/github.com/globus/action-provider-tools/.venv/lib/python3.6/site-packages
Requires: pybase62, isodate, jsonschema, globus-sdk, dogpile.cache, pyyaml, pydantic, arrow
Required-by:
```
After:
```
Name: globus-action-provider-tools
Version: 0.11.2
Summary: Tools to help developers build services that implement the Action Provider specification.
Home-page: None
Author: Jim Pruyne
Author-email: pruyne@globus.org
License: Apache-2.0
Location: /Users/uriel/Projects/github.com/globus/action-provider-tools/.venv/lib/python3.6/site-packages
Requires: pybase62, isodate, jsonschema, globus-sdk, dogpile.cache, pyyaml, pydantic, arrow
Required-by:
```
