### PR TITLE
Updates the CI to refer to pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Action Provider Tools CI
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
 
 jobs:


### PR DESCRIPTION
Client side updates to match the `master`->`main` rename as well as the the new `production` branch usage.

The commands to update the repo locally are extremely the same:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```