### PR TITLE
Adds scriv for changelog management

### DIFF
--- a/.github/workflows/has_changelog.yaml
+++ b/.github/workflows/has_changelog.yaml
@@ -4,4 +4,4 @@ on:
 
 jobs:
   call-scriv-workflow:
-    uses: globus/globus-automate-client/.github/workflows/has_changelog.yaml@80f34115159a1dec25a78772865341c6e65ee0f9
+    uses: globus/globus-automate-client/.github/workflows/has_changelog.yaml@main

--- a/.github/workflows/has_changelog.yaml
+++ b/.github/workflows/has_changelog.yaml
@@ -4,4 +4,4 @@ on:
 
 jobs:
   call-scriv-workflow:
-    uses: globus/globus-automate-client/.github/workflows/has_changelog.yaml@main
+    uses: globus/globus-automate-client/.github/workflows/has_changelog.yaml@80f34115159a1dec25a78772865341c6e65ee0f9

--- a/.github/workflows/has_changelog.yaml
+++ b/.github/workflows/has_changelog.yaml
@@ -1,0 +1,7 @@
+name: Enforce Changelog Fragment
+on:
+  - pull_request
+
+jobs:
+  call-scriv-workflow:
+    uses: globus/globus-automate-client/.github/workflows/has_changelog.yaml@main

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,142 @@
+CHANGELOG
+#########
+
+Unreleased changes
+==================
+
+Unreleased changes are documented in files in the `changelog.d`_ directory.
+
+..  _changelog.d: https://github.com/globus/action-provider-tools/tree/main/changelog.d
+
+..  scriv-insert-here
+
+0.11.4 - 2021-11-01
+===================
+
+Features
+--------
+
+- Adds caching to the following Globus Auth operations: token introspection,
+  group membership, dependent token grants.
+
+Documentation
+-------------
+
+- Adds documentation around the new caching behavior:
+  https://action-provider-tools.readthedocs.io/en/latest/toolkit/caching.html 
+
+
+0.11.3 - 2021-05-27
+===================
+
+Features
+--------
+
+- Bumps globus-sdk version dependency.
+
+0.11.2 - 2021-05-21
+===================
+
+Features
+--------
+
+- Logs authentication errors when a token fails introspection or token validation.
+
+Bugfixes
+--------
+
+- Updates pydantic version to address CVE-2021-29510
+
+0.11.1 - 2021-04-30
+===================
+
+Features
+--------
+
+- Allows the detail field to be a string.
+- Improves logging output in the case where there is an Action Provider throws
+  Exceptions or an authentication issue. 
+- Allows for environment variable configuration.
+- Bundles Flask an an optional dependency. See the README.md for information on
+  installing the toolkit with Flask.
+- Stabilizes package API.
+
+Bugfixes
+--------
+
+- Updates serialization to output timezone aware datatime objects
+- Updates the return type for Action Resume operations to allow for status codes
+  to be returned from the route.
+- Cleanly separates the Flask HTTP components from the plain Python components.
+
+Deprecations
+------------
+
+- The Flask Callback Loader Helper is now deprecated in favor of the Flask
+  Blueprint Helper. 
+
+0.11.0 - 2021-03-29
+===================
+
+Features
+--------
+
+- Provide helpers to standardize output formats for INACTIVE and FAILED states
+- Adds a new resume operation to the helpers which is used to signal that an
+  INACTIVE Action may be resumed.
+
+0.10.5 - 2021-01-27
+===================
+
+Features
+--------
+
+- Adds exceptions that can be raised from Flask views to return standardized
+  JSON responses.
+- Adds support for Action Provider schema definitions based on Pydantic.
+- Migrates ActionStatus, ActionRequest, and ActionProviderDescription to
+  Pydantic classes.
+
+Bugfixes
+--------
+
+- Modifies ActionProvider introspection endpoint creation on the
+  ActionProviderBlueprint so that HTTP requests with and without trailing
+  slashes receive the same results.
+
+Documentation
+-------------
+
+- Action Provider Pydantic classes:
+  https://action-provider-tools.readthedocs.io/en/latest/toolkit/validation.html
+- Action Provider Pydantic input schema support:
+  https://action-provider-tools.readthedocs.io/en/latest/examples/input_schemas.html#pydantic
+
+
+0.10.4 - 2020-10-14
+===================
+
+Features
+--------
+
+- Improves testing tools for isolating tests between different instances of
+  ActionProviderBlueprints and the Flask helpers. 
+
+0.10.3 - 2020-10-01
+===================
+
+Features
+--------
+
+- Adds a shared patch to the testing library to mock out an
+  ActionProviderBlueprints TokenChecker 
+- Users can now specify a Globus Auth Client Name (legacy) when creating an
+  instance of the ActionProviderBlueprint 
+- Users can now specify multiple acceptable scopes when creating an instance of
+  the ActionProviderBlueprint 
+
+Bugfixes
+--------
+
+- Fixes an issue in the ActionProviderBlueprint where registering multiple
+  Blueprints on a Flask app would only register one set of routes

--- a/changelog.d/20211207_162847_uriel_use_scriv.rst
+++ b/changelog.d/20211207_162847_uriel_use_scriv.rst
@@ -1,0 +1,5 @@
+Documentation
+-------------
+
+- Add a CHANGELOG and include it in the documentation.
+- Use scriv for CHANGELOG management.

--- a/changelog.d/README.rst
+++ b/changelog.d/README.rst
@@ -1,0 +1,29 @@
+About ``changelog.d/``
+======================
+
+The ``changelog.d/`` directory contains changelog fragments.
+
+Creating fragments
+------------------
+
+Changelog fragments are created during development to document and categorize changes.
+The files are created and automatically named using the ``scriv create`` command.
+
+To correctly include your GitHub username in the fragment filename,
+run this command to modify your global git configuration:
+
+..  code-block:: shell
+    
+    git config --global github.user GITHUB_USERNAME
+
+Collecting fragments
+--------------------
+
+The fragments are collected and collated during the release process using this command:
+
+..  code-block:: shell
+
+    scriv collect --version $(poetry version -s)
+
+(`scriv issue #44 <https://github.com/nedbat/scriv/issues/44>`_ discusses how to
+read the version directly from ``pyproject.toml``.)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,3 @@
+:tocdepth: 2
+
+..  include:: ../../CHANGELOG.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,4 +44,5 @@ throughout the Globus Automate platform.
    installation
    toolkit
    examples
+   changelog
    license

--- a/poetry.lock
+++ b/poetry.lock
@@ -142,6 +142,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "click-log"
+version = "0.3.2"
+description = "Logging integration for Click"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+click = "*"
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
@@ -694,6 +705,24 @@ python-versions = "*"
 docutils = ">=0.7"
 
 [[package]]
+name = "scriv"
+version = "0.12.0"
+description = "Scriv changelog management tool"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+attrs = "*"
+click = "*"
+click-log = "*"
+jinja2 = "*"
+tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "sexpdata"
 version = "0.0.3"
 description = "S-expression parser for Python"
@@ -968,7 +997,7 @@ flask = ["flask"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "55342e1d7e3e5de4aa63b029f09620774268ea825e97fa6b48cdb231445ba435"
+content-hash = "2b972a08248e07d1969a41d0b6c533559820fc4552c200a9f456ac8182694ff7"
 
 [metadata.files]
 alabaster = [
@@ -1066,6 +1095,10 @@ charset-normalizer = [
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
+click-log = [
+    {file = "click-log-0.3.2.tar.gz", hash = "sha256:16fd1ca3fc6b16c98cea63acf1ab474ea8e676849dc669d86afafb0ed7003124"},
+    {file = "click_log-0.3.2-py2.py3-none-any.whl", hash = "sha256:eee14dc37cdf3072158570f00406572f9e03e414accdccfccd4c538df9ae322c"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -1516,6 +1549,10 @@ requests = [
 ]
 rstcheck = [
     {file = "rstcheck-3.3.1.tar.gz", hash = "sha256:92c4f79256a54270e0402ba16a2f92d0b3c15c8f4410cb9c57127067c215741f"},
+]
+scriv = [
+    {file = "scriv-0.12.0-py2.py3-none-any.whl", hash = "sha256:62d9d91466a6c629fb72964290906eba1331d4d53c219e95c57f050b62d30ca5"},
+    {file = "scriv-0.12.0.tar.gz", hash = "sha256:0c1b055afea1773d50f13728f301dd4aa0d35e68be4e2f1e7373b51ec225de0a"},
 ]
 sexpdata = [
     {file = "sexpdata-0.0.3.tar.gz", hash = "sha256:1ac827a616c5e87ebb60fd6686fb86f8a166938c645f4089d92de3ffbdd494e0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ isort = "^5.9.3"
 types-cachetools = "^4.2.4"
 types-PyYAML = "^6.0.0"
 types-requests = "^2.25.11"
+scriv = {extras = ["toml"], version = "^0.12.0"}
 
 [tool.isort]
 multi_line_output = 3
@@ -75,3 +76,6 @@ line_length = 88
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
+
+[tool.scriv]
+categories = ["Features", "Bugfixes", "Documentation", "Deprecations"]


### PR DESCRIPTION
This PR adds `scriv` as a development dependency, adds a CHANGELOG.rst file which documents all the PyPI releases so far, adds that CHANGELOG to our readthedocs site builds, and references the has_changelog workflow we created in the globus-automate-client repo to enforce future pull requests contain a changelog fragment.