### PR TITLE
Address invalid grant errors

### DIFF
--- a/changelog.d/20221026_165824_kurtmckee_address_invalid_grant_error_sc_19538.rst
+++ b/changelog.d/20221026_165824_kurtmckee_address_invalid_grant_error_sc_19538.rst
@@ -1,0 +1,7 @@
+Bugfixes
+--------
+
+- Fix a crash that occurs when an HTTP 400 "invalid grant" error is received
+  from Globus Auth while getting an authorizer for a given scope.
+
+  This is now caught by ``AuthState.get_authorizer_for_scope()`` and ``None`` is returned.

--- a/globus_action_provider_tools/authentication.py
+++ b/globus_action_provider_tools/authentication.py
@@ -2,6 +2,7 @@ import logging
 from time import time
 from typing import FrozenSet, Iterable, List, Optional, Union, cast
 
+import globus_sdk
 from cachetools import TTLCache
 from globus_sdk import (
     AccessTokenAuthorizer,
@@ -238,7 +239,7 @@ class AuthState(object):
             dep_tkn_resp = self.get_dependent_tokens(
                 bypass_cache_lookup=bypass_dependent_token_cache
             ).by_scopes[scope]
-        except KeyError:
+        except (KeyError, globus_sdk.AuthAPIError):
             log.warning(
                 f"Unable to create GlobusAuthorizer for scope {scope}. Using 'None'",
                 exc_info=True,

--- a/tests/api-fixtures/token.yaml
+++ b/tests/api-fixtures/token.yaml
@@ -1,5 +1,12 @@
 # POST /v2/oauth2/token
 
+invalid-grant:
+  service: auth
+  path: /v2/oauth2/token
+  method: POST
+  status: 400
+  json: {"error":"invalid_grant"}
+
 success:
   service: auth
   path: /v2/oauth2/token

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -111,3 +111,9 @@ def test_auth_state_caching_across_instances(auth_state, freeze_time, mocked_res
     # resulting in no additional HTTP calls.
     assert len(duplicate_auth_state.identities) == len(response.metadata["identities"])
     assert len(mocked_responses.calls) == 1
+
+
+def test_invalid_grant_exception(auth_state):
+    load_response("token-introspect", case="success")
+    load_response("token", case="invalid-grant")
+    assert auth_state.get_authorizer_for_scope("doesn't matter") is None


### PR DESCRIPTION
> NOTE:
>
> This PR temporarily targets a non-main branch as its base to isolate the commit this fix.
>
> The base branch can be switched back to `main` when PR #65 is merged.

Bugfixes
--------

- Fix a crash that occurs when an HTTP 400 "invalid grant" error is received
  from Globus Auth while getting an authorizer for a given scope.

  This is now caught by ``AuthState.get_authorizer_for_scope()`` and ``None`` is returned.
