### PR TITLE
Patch [sc-19668]: Rephrase JsonProvider to avoid type error

### DIFF
--- a/globus_action_provider_tools/flask/helpers.py
+++ b/globus_action_provider_tools/flask/helpers.py
@@ -4,7 +4,7 @@ import inspect
 import json
 from enum import Enum
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, Optional, Set, Type
+from typing import Any, Callable, Dict, Iterable, Set, Type
 
 import flask
 from flask import Request, current_app, jsonify
@@ -212,15 +212,18 @@ try:
 except ImportError:
     # Flask < 2.2: Use the deprecated JSON encoder interface.
     json_provider_available = False
-    JsonProvider: Optional["DefaultJSONProvider"] = None
+
+    JsonProvider: type[DefaultJSONProvider] | None = None
 else:
     # Flask >= 2.2: Use the new JSON provider interface.
     json_provider_available = True
 
-    class JsonProvider(DefaultJSONProvider):  # type: ignore[no-redef]
+    class _JsonProvider(DefaultJSONProvider):
         @staticmethod
         def default(o: Any) -> Any:
             return convert_to_json(o)
+
+    JsonProvider = _JsonProvider
 
 
 def assign_json_provider(app_or_blueprint: flask.Flask | flask.Blueprint):


### PR DESCRIPTION
I'm okay with not changing this, but this is my thought on how to avoid the type-ignore.

I think `mypy` sees `class` as redefining a name in a way that it does not see assignment. It's a type-checker artifact, and I could understand the complaint that the classname now has a misleading underscore, but I think this is still nicer than the type-ignore.