### PR TITLE
Use poetry-core as the build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,8 @@ use_parentheses = true
 line_length = 88
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.scriv]
 categories = [


### PR DESCRIPTION
This allows tools like `tox` to install mandatory dependencies much more quickly (due to only requiring standalone `poetry-core` instead of `poetry` plus all of its many CLI dependencies).