### PR TITLE
Fix "Publish to PyPI" CI action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: PyPi Publish
+name: Publish to PyPI
 
 on:
   release:
@@ -7,18 +7,18 @@ on:
 
 jobs:
   publish:
-    name: Publish a release to PyPi
+    name: Publish a release to PyPI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: Set target python version
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.6.x"
+          python-version: "3.11"
 
       - name: Install poetry
         run: python -m pip install poetry


### PR DESCRIPTION
This has been tested using the following steps:

1. Add one additional commit that bumps the version to "0.13.0b19283726".
2. Create a new GitHub release.
3. Confirm the release was pushed successfully to PyPI.

The steps were undone using the following steps:

1. Remove the version-change commit (`git reset --hard HEAD^; git push --force`)
2. Delete the GitHub release and tag.
3. Delete (NOT a yank!) the release from PyPI.
