### PR TITLE
Remove a no-op call to Globus Auth during ``TokenChecker`` instantiation

### DIFF
--- a/changelog.d/20221216_151552_kurtmckee_rm_dummy_auth_call.rst
+++ b/changelog.d/20221216_151552_kurtmckee_rm_dummy_auth_call.rst
@@ -1,0 +1,6 @@
+Changes
+-------
+
+-   Remove an unused parameter from ``TokenChecker``: ``cache_config``.
+-   Remove a no-op call to Globus Auth during ``TokenChecker`` instantiation.
+-   Remove the ``ConfigurationError`` class.

--- a/globus_action_provider_tools/authentication.py
+++ b/globus_action_provider_tools/authentication.py
@@ -15,8 +15,6 @@ from globus_sdk import (
     RefreshTokenAuthorizer,
 )
 
-from globus_action_provider_tools.errors import ConfigurationError
-
 log = logging.getLogger(__name__)
 
 
@@ -356,7 +354,6 @@ class TokenChecker:
         client_secret: str,
         expected_scopes: Iterable[str],
         expected_audience: Optional[str] = None,
-        cache_config: Optional[dict] = None,
     ) -> None:
         self.auth_client = ConfidentialAppAuthClient(client_id, client_secret)
         self.default_expected_scopes = frozenset(expected_scopes)
@@ -365,13 +362,6 @@ class TokenChecker:
             self.expected_audience = client_id
         else:
             self.expected_audience = expected_audience
-
-        # Try to check a 'token' and fail fast here in case client_id/secret are bad:
-        try:
-            self.check_token("NotAToken").introspect_token()
-        except GlobusAPIError as err:
-            if err.http_status == 401:
-                raise ConfigurationError("Check client_id and client_secret", err)
 
     def check_token(
         self, access_token: str, expected_scopes: Iterable[str] = None

--- a/globus_action_provider_tools/errors.py
+++ b/globus_action_provider_tools/errors.py
@@ -8,9 +8,3 @@ class AuthenticationError(ActionProviderToolsError):
     """
     An Exception class for errors triggered due to Authentication.
     """
-
-
-class ConfigurationError(ActionProviderToolsError):
-    """
-    An Exception class for errors triggered by misconfiguration.
-    """

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -6,12 +6,7 @@ import globus_sdk
 import pytest
 from globus_sdk._testing import load_response
 
-from globus_action_provider_tools.authentication import (
-    AuthState,
-    TokenChecker,
-    identity_principal,
-)
-from globus_action_provider_tools.errors import ConfigurationError
+from globus_action_provider_tools.authentication import AuthState, identity_principal
 
 
 def get_auth_state_instance(
@@ -40,16 +35,6 @@ def auth_state(mocked_responses) -> t.Iterator[AuthState]:
     AuthState.group_membership_cache.clear()
     AuthState.introspect_cache.clear()
     yield get_auth_state_instance(["expected-scope"], "expected-audience")
-
-
-def test_token_checker_bad_credentials():
-    load_response("token-introspect", case="invalid-client")
-    with pytest.raises(ConfigurationError):
-        TokenChecker(
-            client_id="bogus",
-            client_secret="bogus",
-            expected_scopes=("fakescope",),
-        )
 
 
 def test_get_identities(auth_state, freeze_time):


### PR DESCRIPTION
Changes
-------

-   Remove an unused parameter from ``TokenChecker``: ``cache_config``.
-   Remove a no-op call to Globus Auth during ``TokenChecker`` instantiation.
