### PR TITLE
Remove deprecation warning

### DIFF
--- a/changelog.d/20221216_222633_sirosen_remove_module_deprecation_warning.rst
+++ b/changelog.d/20221216_222633_sirosen_remove_module_deprecation_warning.rst
@@ -1,0 +1,5 @@
+Deprecations
+------------
+
+- Imports from ``globus_action_provider_tools.flask`` will no longer emit a
+  ``DeprecationWarning``

--- a/globus_action_provider_tools/flask/api_helpers.py
+++ b/globus_action_provider_tools/flask/api_helpers.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 from typing import List, Optional
 
 import flask
@@ -41,15 +40,18 @@ from globus_action_provider_tools.validation import (
     request_validator,
 )
 
-warnings.warn(
-    (
-        "The globus_action_provider_tools.flask.api_helpers module is deprecated "
-        "and will be removed in 0.12.0. Please consider using the "
-        "globus_action_provider_tools.flask.apt_blueprint module instead."
-    ),
-    DeprecationWarning,
-    stacklevel=2,
-)
+# this deprecation warning was added in a past version, but never acted upon
+# remove the warning until we have clarity on the maintenance status of this module
+#
+# warnings.warn(
+#     (
+#         "The globus_action_provider_tools.flask.api_helpers module is deprecated "
+#         "and will be removed in 0.12.0. Please consider using the "
+#         "globus_action_provider_tools.flask.apt_blueprint module instead."
+#     ),
+#     DeprecationWarning,
+#     stacklevel=2,
+# )
 
 
 _request_schema_types = {"run": "ActionRequest"}


### PR DESCRIPTION
This change makes no comment on the desirability of this module, but it was deprecated and then *not* removed, and is still relied upon for examples.

Without clarity on its true deprecation status, the sensible near-term course is to remove this warning as "spurious", even if it reflects some real desire to remove the module.