### PR TITLE
Add slyp as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
+
+  - repo: https://github.com/sirosen/slyp
+    rev: 0.1.1
+    hooks:
+      - id: slyp


### PR DESCRIPTION

This PR adds slyp as a pre-commit hook.

For some affected repos, the isort hook repo was updated as well.

## How this change was made

I added slyp as a pre-commit hook, then manually resolved all reported errors.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>