### PR TITLE
Omit input data from validation errors

### DIFF
--- a/changelog.d/20240123_134319_ada_fix_error_description_field_behavior.rst
+++ b/changelog.d/20240123_134319_ada_fix_error_description_field_behavior.rst
@@ -1,0 +1,7 @@
+Changes
+-------
+
+- Error descriptions in responses are now always strings (previously they could also
+  be lists of strings or lists of dictionaries).
+- Input validation errors now use an HTTP response status code of 422.
+- Validation errors no longer return input data in their description.

--- a/globus_action_provider_tools/validation.py
+++ b/globus_action_provider_tools/validation.py
@@ -45,17 +45,12 @@ response_validator = request_validator
 def validate_data(
     data: Dict[str, Any], validator: jsonschema.protocols.Validator
 ) -> ValidationResult:
-    error_messages = []
-    for error in validator.iter_errors(data):
-        if error.path:
-            # Elements of the error path may be integers or other non-string types,
-            # but we need strings for use with join()
-            error_path_for_message = ".".join([str(x) for x in error.path])
-            error_message = f"'{error_path_for_message}' invalid due to {error.message}"
-        else:
-            error_message = error.message
-        error_messages.append(error_message)
+    # TODO: If python-jsonschema introduces a means of returning error messages that
+    # do not include input data, modify this to return more specific error information.
+    if not validator.is_valid(data):
+        message = "Input failed schema validation"
+        result = ValidationResult(errors=[message], error_msg=message)
+    else:
+        result = ValidationResult(errors=[], error_msg=None)
 
-    error_msg = "; ".join(error_messages) if error_messages else None
-    result = ValidationResult(errors=error_messages, error_msg=error_msg)
     return result

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,6 +7,7 @@ from globus_action_provider_tools.flask.exceptions import (
     ActionNotFound,
     ActionProviderError,
     BadActionRequest,
+    RequestValidationError,
     UnauthorizedRequest,
 )
 
@@ -18,6 +19,7 @@ from globus_action_provider_tools.flask.exceptions import (
         ActionNotFound,
         ActionProviderError,
         BadActionRequest,
+        RequestValidationError,
         UnauthorizedRequest,
     ],
 )

--- a/tests/test_flask_helpers/test_validation_helpers.py
+++ b/tests/test_flask_helpers/test_validation_helpers.py
@@ -9,6 +9,7 @@ from jsonschema.validators import Draft7Validator
 from globus_action_provider_tools.flask.exceptions import (
     ActionProviderError,
     BadActionRequest,
+    RequestValidationError,
 )
 from globus_action_provider_tools.flask.helpers import (
     get_input_body_validator,
@@ -88,19 +89,18 @@ def test_validating_action_request():
 
 
 @pytest.mark.parametrize(
-    "document, type_, message",
+    "document, message",
     (
-        ("wrong object type", "type_error.dict", "value is not a valid dict"),
-        ({1: "wrong key type"}, "type_error.str", "str type expected"),
+        ("wrong object type", "Field '__root__': value is not a valid dict"),
+        ({1: "wrong key type"}, "Field '__root__.__key__': str type expected"),
     ),
 )
-def test_validate_input_typeerror(document, type_, message):
+def test_validate_input_typeerror(document, message):
     """Verify that the `request_json` argument types are validated."""
 
     ap_description.input_schema = json.dumps(action_provider_json_input_schema)
     validator = get_input_body_validator(ap_description)
     with pytest.raises(BadActionRequest) as catcher:
         validate_input(document, validator)
-    assert catcher.value.get_response().status_code == 400
-    assert catcher.value.get_description()[0]["msg"] == message
-    assert catcher.value.get_description()[0]["type"] == type_
+    assert catcher.value.get_response().status_code == 422
+    assert catcher.value.description == message


### PR DESCRIPTION
Additionally, ensure that these errors only produce string descriptions, allowing us to normalize error shapes. Further still, adopt HTTP response status code 422 for errors where input is parsable but in an invalid form.

(n.b., in addition to the previously discussed `python-jsonschema` error messages, this also addresses error dicts emitted by Pydantic, which also include input data.)

I tried to keep this quite narrow, though given that validation errors appear to be the only source of non-string error descriptions, I took the adjacent opportunity to simplify the base error model at the same time.

Note that one of the example APs ("whattimeisit") returns errors in a completely different format from the classes we provide. As such, I did not address it here. Open to continuing to noodle on the validation error messaging if anyone has ideas for simple, obvious improvements.

I'm considering whether additional tests are warranted as this handling appears to be somewhat under-exercised.

Updating APs to use this release should allow validation errors to appear correctly in Flows event logs, as the error parsing performed by the Globus Python SDK will begin to recognize these error messages once `description` is a string.