### PR TITLE
Re-enable Flake8; resolve listed issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-exclude = .git,.tox,__pycache__,.eggs,dist,.venv*,build
-max-line-length = 88
-extend-ignore = W503,E203,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,13 @@ repos:
     hooks:
       - id: isort
 
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-bugbear==24.2.6
+
   - repo: https://github.com/sirosen/slyp
     rev: 0.6.0
     hooks:

--- a/globus_action_provider_tools/authentication.py
+++ b/globus_action_provider_tools/authentication.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import logging
 from time import time
-from typing import FrozenSet, Iterable, List, Optional, Union, cast
+from typing import Iterable, cast
 
 import globus_sdk
 from cachetools import TTLCache

--- a/globus_action_provider_tools/flask/api_helpers.py
+++ b/globus_action_provider_tools/flask/api_helpers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import List, Optional
 
 import flask
 from flask import jsonify, request

--- a/globus_action_provider_tools/flask/helpers.py
+++ b/globus_action_provider_tools/flask/helpers.py
@@ -4,7 +4,7 @@ import inspect
 import json
 from enum import Enum
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, Optional, Set, Type
+from typing import Any, Callable, Dict, Iterable
 
 import flask
 import jsonschema

--- a/globus_action_provider_tools/flask/request_lifecycle_hooks/cloudwatch_metrics.py
+++ b/globus_action_provider_tools/flask/request_lifecycle_hooks/cloudwatch_metrics.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 import typing as t
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from flask import Response, g
 

--- a/tests/test_flask_helpers/conftest.py
+++ b/tests/test_flask_helpers/conftest.py
@@ -12,7 +12,7 @@ from globus_action_provider_tools.flask import (
     add_action_routes_to_blueprint,
 )
 from globus_action_provider_tools.flask.helpers import assign_json_provider
-from globus_action_provider_tools.testing.fixtures import (
+from globus_action_provider_tools.testing.fixtures import (  # noqa: F401 unused import
     apt_blueprint_noauth,
     flask_helpers_noauth,
 )
@@ -29,7 +29,7 @@ from .app_utils import (
 
 
 @pytest.fixture()
-def aptb_app(apt_blueprint_noauth, auth_state):
+def aptb_app(apt_blueprint_noauth, auth_state):  # noqa: F811 redefinition
     """
     This fixture creates a Flask app using the ActionProviderBlueprint
     helper. The function form of the decorators are used to register each
@@ -56,7 +56,7 @@ def aptb_app(apt_blueprint_noauth, auth_state):
 
 
 @pytest.fixture()
-def add_routes_app(flask_helpers_noauth, auth_state):
+def add_routes_app(flask_helpers_noauth, auth_state):  # noqa: F811 redefinition
     """
     This fixture creates a Flask app with routes loaded via the
     add_action_routes_to_blueprint Flask helper.

--- a/tests/test_flask_helpers/test_validation_helpers.py
+++ b/tests/test_flask_helpers/test_validation_helpers.py
@@ -10,7 +10,6 @@ from jsonschema.validators import Draft7Validator
 from globus_action_provider_tools.flask.exceptions import (
     ActionProviderError,
     BadActionRequest,
-    RequestValidationError,
 )
 from globus_action_provider_tools.flask.helpers import (
     get_input_body_validator,

--- a/tox.ini
+++ b/tox.ini
@@ -83,3 +83,7 @@ commands =
     # Update pre-commit hook versions
     pre-commit autoupdate
     upadup
+
+
+[flake8]
+extend-ignore = E203,E501,E701


### PR DESCRIPTION
A configuration file existed but Flake8 was not actually getting run. This PR:

* Enables Flake8 as a pre-commit hook
* Resolves the errors found

(There are line length issues that are ignored by black -- even >120 characters long! -- which cannot be resolved by a sane Flake8 configuration; therefore the line length checks in Flake8 are currently completely disabled.)