### PR TITLE
Prevent `TypeError`s during pydantic location formatting

### DIFF
--- a/changelog.d/20240319_114453_kurtmckee_prevent_type_error_sc_30842.rst
+++ b/changelog.d/20240319_114453_kurtmckee_prevent_type_error_sc_30842.rst
@@ -1,0 +1,6 @@
+Bugfixes
+--------
+
+*   Prevent ``TypeError``\s from occurring during pydantic error formatting.
+
+    This was caused by integer list indexes in pydantic error locations.

--- a/globus_action_provider_tools/flask/helpers.py
+++ b/globus_action_provider_tools/flask/helpers.py
@@ -211,7 +211,16 @@ def pydantic_input_validation(
     try:
         validator(**action_input)
     except ValidationError as ve:
-        messages = [f"Field '{'.'.join(e['loc'])}': {e['msg']}" for e in ve.errors()]
+        messages = []
+        for error in ve.errors():
+            path = []
+            for location in error["loc"]:
+                if isinstance(location, str):
+                    path.append(f".{location}")
+                else:
+                    path.append(f"[{location}]")
+            field = "".join(path)[1:]  # Remove the leading period.
+            messages.append(f"Field '{field}': {error['msg']}")
         raise RequestValidationError("; ".join(messages))
 
 


### PR DESCRIPTION
Bugfixes
--------

*   Prevent ``TypeError``s from occurring during pydantic error formatting.

    This was caused by integer list indexes in pydantic error locations.
