### PR TITLE
Reduce I/O with Globus Auth

### DIFF
--- a/changelog.d/20240328_165035_kurtmckee_skip_checking_bogus_tokens_sc_30786.rst
+++ b/changelog.d/20240328_165035_kurtmckee_skip_checking_bogus_tokens_sc_30786.rst
@@ -1,0 +1,6 @@
+Bugfixes
+--------
+
+-   Allow package consumers to run with Python optimizations enabled.
+
+    This is supported by replacing ``assert`` statements with ``raise AssertionError``.

--- a/changelog.d/20240329_091032_kurtmckee_skip_checking_bogus_tokens_sc_30786.rst
+++ b/changelog.d/20240329_091032_kurtmckee_skip_checking_bogus_tokens_sc_30786.rst
@@ -1,0 +1,4 @@
+Changes
+-------
+
+-   Remove references to web browsers from HTTP 401 Unauthorized responses.

--- a/changelog.d/20240329_112034_kurtmckee_skip_checking_bogus_tokens_sc_30786.rst
+++ b/changelog.d/20240329_112034_kurtmckee_skip_checking_bogus_tokens_sc_30786.rst
@@ -1,0 +1,10 @@
+Changes
+-------
+
+-   Reduce I/O with Globus Auth when possible.
+
+    *   If the action provider is visible to ``"public"``,
+        introspection requests are allowed without checking tokens.
+    *   If the bearer token is missing, malformed, or is too short or long,
+        the incoming request is summarily rejected with HTTP 401
+        without introspecting the token.

--- a/globus_action_provider_tools/errors.py
+++ b/globus_action_provider_tools/errors.py
@@ -8,3 +8,13 @@ class AuthenticationError(ActionProviderToolsError):
     """
     An Exception class for errors triggered due to Authentication.
     """
+
+
+class UnverifiedAuthenticationError(AuthenticationError):
+    """
+    Indicates that a token has been rejected without an I/O call to Globus Auth.
+
+    This may occur if the request is missing an Authorization header,
+    or if the header value is malformed (such as missing the ``"Bearer "`` prefix),
+    or if the token does not meet known token length requirements.
+    """

--- a/globus_action_provider_tools/flask/api_helpers.py
+++ b/globus_action_provider_tools/flask/api_helpers.py
@@ -207,13 +207,16 @@ def add_action_routes_to_blueprint(
             response.headers["Access-Control-Expose-Headers"] = "*"
             return response, 204
 
-        auth_state = check_token(request, checker)
-        if not auth_state.check_authorization(
-            provider_description.visible_to,
-            allow_public=True,
-            allow_all_authenticated_users=True,
-        ):
-            raise ActionNotFound
+        # Check tokens if "public" is not in the *visible_to* list.
+        if "public" not in provider_description.visible_to:
+            auth_state = check_token(request, checker)
+            if not auth_state.check_authorization(
+                provider_description.visible_to,
+                allow_public=True,
+                allow_all_authenticated_users=True,
+            ):
+                raise ActionNotFound
+
         response = flask.make_response(jsonify(provider_description))
         response.headers["Access-Control-Allow-Origin"] = "*"
         return response, 200

--- a/globus_action_provider_tools/flask/exceptions.py
+++ b/globus_action_provider_tools/flask/exceptions.py
@@ -63,7 +63,10 @@ class ActionConflict(ActionProviderToolsException, Conflict):
 
 
 class UnauthorizedRequest(ActionProviderToolsException, Unauthorized):
-    pass
+    description = (
+        "The server could not verify that you are authorized "
+        "to access the URL requested."
+    )
 
 
 class ActionProviderError(ActionProviderToolsException, InternalServerError):

--- a/globus_action_provider_tools/flask/helpers.py
+++ b/globus_action_provider_tools/flask/helpers.py
@@ -250,7 +250,7 @@ def assign_json_provider(app_or_blueprint: flask.Flask | flask.Blueprint):
     """
 
     if json_provider_available:
-        assert JsonProvider is not None
+        assert JsonProvider is not None  # mypy hack
         app_or_blueprint.json = JsonProvider(app_or_blueprint)
     else:
         app_or_blueprint.json_encoder = ActionProviderJsonEncoder

--- a/globus_action_provider_tools/flask/helpers.py
+++ b/globus_action_provider_tools/flask/helpers.py
@@ -20,7 +20,10 @@ from globus_action_provider_tools.data_types import (
     RequestObject,
     convert_to_json,
 )
-from globus_action_provider_tools.errors import AuthenticationError
+from globus_action_provider_tools.errors import (
+    AuthenticationError,
+    UnverifiedAuthenticationError,
+)
 from globus_action_provider_tools.flask.exceptions import (
     ActionProviderError,
     ActionProviderToolsException,
@@ -100,12 +103,16 @@ def action_status_return_to_view_return(
 
 
 def check_token(request: Request, checker: TokenChecker) -> AuthState:
-    """
-    Parses a Flask request to extract its bearer token.
-    """
-    access_token = request.headers.get("Authorization", "").strip()
-    if access_token.startswith("Bearer "):
-        access_token = access_token[len("Bearer ") :]
+    """Extract and validate a bearer token and return an AuthState instance."""
+
+    access_token = request.headers.get("Authorization")
+    if access_token is None:
+        raise UnverifiedAuthenticationError("No Authorization header received")
+    if not access_token.startswith("Bearer "):
+        raise UnverifiedAuthenticationError("No Bearer token in Authorization header")
+    access_token = access_token[len("Bearer ") :].strip()
+    if not 10 <= len(access_token) <= 2048:
+        raise UnverifiedAuthenticationError("Bearer token length is unexpected")
     auth_state = checker.check_token(access_token)
     return auth_state
 

--- a/tests/test_flask_helpers/request_lifecycle_hooks/test_cloudwatch_metrics.py
+++ b/tests/test_flask_helpers/request_lifecycle_hooks/test_cloudwatch_metrics.py
@@ -63,7 +63,11 @@ def test_routes_emit_emf_logs(
     app.register_blueprint(aptb)
 
     req = {"request_id": "0", "body": {"echo_string": "This is a test"}}
-    app.test_client().post("/tracked/run", json=req)
+    app.test_client().post(
+        "/tracked/run",
+        json=req,
+        headers=[("Authorization", "Bearer AAAAAAAAAA")],
+    )
     out, _ = capsys.readouterr()
     emf_log = json.loads(out)
 

--- a/tests/test_flask_helpers/test_routes.py
+++ b/tests/test_flask_helpers/test_routes.py
@@ -86,46 +86,106 @@ def test_introspect_cors_requests(request, app_fixture):
     assert list(introspection_cors_response.access_control_expose_headers) == ["*"]
 
 
+@pytest.mark.parametrize("app_fixture", ["aptb_app", "add_routes_app"])
+@pytest.mark.parametrize("api_version", ["1.0", "1.1"])
+@pytest.mark.parametrize(
+    "authorization_header",
+    (
+        pytest.param(None, id="missing Authorization header"),
+        pytest.param("", id="blank header value"),
+        pytest.param("  ", id="whitespace header value"),
+        pytest.param("A" * 100, id="no 'Bearer ' prefix"),
+        pytest.param("Bearer " + "A" * 9, id="short token"),
+        pytest.param("Bearer " + "A" * 2049, id="long token"),
+    ),
+)
+def test_bogus_authorization_headers_are_rejected_without_io(
+    request, app_fixture, api_version, authorization_header
+):
+    app: flask.Flask = request.getfixturevalue(app_fixture)
+    client = app.test_client()
+    _, bp = list(app.blueprints.items())[0]
+
+    bp.input_schema = ActionProviderPydanticInputSchema
+
+    headers = []
+    if authorization_header is not None:
+        headers.append(("Authorization", authorization_header))
+
+    if api_version == "1.1":
+        enumeration_resp = ap_enumeration(client, bp.url_prefix, headers=headers)
+        assert enumeration_resp.status_code == 401, enumeration_resp.json
+
+    run_resp = ap_run(client, bp.url_prefix, api_version=api_version, headers=headers)
+    assert run_resp.status_code == 401, run_resp.json
+
+    status_resp = ap_status(
+        client, bp.url_prefix, "any", api_version=api_version, headers=headers
+    )
+    assert status_resp.status_code == 401, status_resp.json
+
+    log_resp = ap_log(
+        client, bp.url_prefix, "any", api_version=api_version, headers=headers
+    )
+    assert log_resp.status_code == 401, log_resp.json
+
+    cancel_resp = ap_cancel(
+        client, bp.url_prefix, "any", api_version=api_version, headers=headers
+    )
+    assert cancel_resp.status_code == 401, cancel_resp.json
+
+    release_resp = ap_release(
+        client, bp.url_prefix, "any", api_version=api_version, headers=headers
+    )
+    assert release_resp.status_code == 401, release_resp.json
+
+
 def ap_introspection(client, url_prefix: str):
     return client.get(url_prefix, follow_redirects=True)
 
 
-def ap_enumeration(client, url_prefix: str):
-    return client.get(f"{url_prefix}/actions")
+def ap_enumeration(client, url_prefix: str, **kwargs):
+    kwargs.setdefault("headers", [("Authorization", "Bearer AAAAAAAAAA")])
+    return client.get(f"{url_prefix}/actions", **kwargs)
 
 
-def ap_run(client, url_prefix: str, *, api_version: str):
+def ap_run(client, url_prefix: str, *, api_version: str, **kwargs):
+    kwargs.setdefault("headers", [("Authorization", "Bearer AAAAAAAAAA")])
     payload = {"request_id": "0", "body": {"echo_string": "This is a test"}}
 
     if api_version == "1.0":
-        return client.post(f"{url_prefix}/run", json=payload)
+        return client.post(f"{url_prefix}/run", json=payload, **kwargs)
     if api_version == "1.1":
-        return client.post(f"{url_prefix}/actions", json=payload)
+        return client.post(f"{url_prefix}/actions", json=payload, **kwargs)
 
 
-def ap_status(client, url_prefix: str, action_id: str, *, api_version: str):
+def ap_status(client, url_prefix: str, action_id: str, *, api_version: str, **kwargs):
+    kwargs.setdefault("headers", [("Authorization", "Bearer AAAAAAAAAA")])
     if api_version == "1.0":
-        return client.get(f"{url_prefix}/{action_id}/status")
+        return client.get(f"{url_prefix}/{action_id}/status", **kwargs)
     if api_version == "1.1":
-        return client.get(f"{url_prefix}/actions/{action_id}")
+        return client.get(f"{url_prefix}/actions/{action_id}", **kwargs)
 
 
-def ap_log(client, url_prefix: str, action_id: str, *, api_version: str):
+def ap_log(client, url_prefix: str, action_id: str, *, api_version: str, **kwargs):
+    kwargs.setdefault("headers", [("Authorization", "Bearer AAAAAAAAAA")])
     if api_version == "1.0":
-        return client.get(f"{url_prefix}/{action_id}/log")
+        return client.get(f"{url_prefix}/{action_id}/log", **kwargs)
     if api_version == "1.1":
-        return client.get(f"{url_prefix}/actions/{action_id}/log")
+        return client.get(f"{url_prefix}/actions/{action_id}/log", **kwargs)
 
 
-def ap_cancel(client, url_prefix: str, action_id: str, *, api_version: str):
+def ap_cancel(client, url_prefix: str, action_id: str, *, api_version: str, **kwargs):
+    kwargs.setdefault("headers", [("Authorization", "Bearer AAAAAAAAAA")])
     if api_version == "1.0":
-        return client.post(f"{url_prefix}/{action_id}/cancel")
+        return client.post(f"{url_prefix}/{action_id}/cancel", **kwargs)
     if api_version == "1.1":
-        return client.post(f"{url_prefix}/actions/{action_id}/cancel")
+        return client.post(f"{url_prefix}/actions/{action_id}/cancel", **kwargs)
 
 
-def ap_release(client, url_prefix: str, action_id: str, *, api_version: str):
+def ap_release(client, url_prefix: str, action_id: str, *, api_version: str, **kwargs):
+    kwargs.setdefault("headers", [("Authorization", "Bearer AAAAAAAAAA")])
     if api_version == "1.0":
-        return client.post(f"{url_prefix}/{action_id}/release")
+        return client.post(f"{url_prefix}/{action_id}/release", **kwargs)
     if api_version == "1.1":
-        return client.delete(f"{url_prefix}/actions/{action_id}")
+        return client.delete(f"{url_prefix}/actions/{action_id}", **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ extras =
 deps =
     -r requirements/test/requirements.txt
     minimum_flask: flask==2.3.0
-commands = coverage run -m pytest
+commands = coverage run -m pytest {posargs}
 
 
 [testenv:coverage_report]


### PR DESCRIPTION
Bugfixes
--------

-   Allow package consumers to run with Python optimizations enabled.

    This is supported by replacing ``assert`` statements with ``raise AssertionError``.


Changes
-------

-   Remove references to web browsers from HTTP 401 Unauthorized responses.
-   Reduce I/O with Globus Auth when possible.

    *   If the action provider is visible to ``"public"``,        introspection requests are allowed without checking tokens.
    *   If the bearer token is missing, malformed, or is too short or long,        the incoming request is summarily rejected with HTTP 401        without introspecting the token.
