### PR TITLE
Migrate to Poetry's `package-mode` option

### DIFF
--- a/requirements/docs/pyproject.toml
+++ b/requirements/docs/pyproject.toml
@@ -1,14 +1,7 @@
 [tool.poetry]
-name = "docs requirements"
-version = "0"
-description = ""
-authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.8"
 sphinx = "*"
 sphinx_material = "*"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"

--- a/requirements/mypy/pyproject.toml
+++ b/requirements/mypy/pyproject.toml
@@ -1,8 +1,5 @@
 [tool.poetry]
-name = "mypy requirements"
-version = "0"
-description = ""
-authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.8"
@@ -10,8 +7,3 @@ mypy = "*"
 types-cachetools = "*"
 types-requests = "*"
 types-pyyaml = "*"
-
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"

--- a/requirements/test/pyproject.toml
+++ b/requirements/test/pyproject.toml
@@ -1,8 +1,5 @@
 [tool.poetry]
-name = "test requirements"
-version = "0"
-description = ""
-authors = []
+package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.8"
@@ -10,7 +7,3 @@ coverage = "*"
 freezegun = "*"
 pytest = "*"
 responses = "*"
-
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION

This PR migrates the dummy package values in `requirements/*/pyproject.toml` files to Poetry's new `package-mode = false` option.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>