### PR TITLE
Replace workflow doc releasing sections with releasing doc

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,17 +1,38 @@
 # Releasing
 
 - Determine a new version number, `VERSION=...`
-- Checkout `main` and ensure you are up to date, `git checkout main; git pull`
-- Create and checkout a release branch, `git checkout -b release/$VERSION`
+
+- Make sure your repo is on `main` and up to date;
+    `git checkout main; git pull`
+
+- Checkout a release branch, `git checkout -b release/$VERSION`
+
 - Update the version number with `poetry version $VERSION`
+
 - Update the changelog, `scriv collect --edit`
-- Add, commit, and push
-    `git commit -m "Bump version for release v$VERSION"`
-- Fast-forward merge the release branch to the `production` branch
-    `git checkout production && git merge --no-ff release/$VERSION`
-- Create a release tag and push,
+
+- Add, commit, and push the release branch
+
+```
+git add pyproject.toml CHANGELOG.rst changelog.d/
+git commit -m "Bump version for release v$VERSION"
+git push -u origin release/$VERSION
+```
+_Note: this assumes `origin` is your desired upstream._
+
+- Create a PR against the `production` branch;
+    `gh pr create -B production -t "Release v$VERSION"`
+
+- After any changes and approval, merge the PR, checkout `production`, and pull;
+    `git checkout production; git pull`
+
+- Create a release tag and push;
     `git tag -s "v$(poetry version -s)" -m "v$(poetry version -s)"`
+    `git push --tags`
+
 - Create a GitHub release, which will auto-publish to pypi
     `gh release create "v$(poetry version -s)" --title "v$(poetry version -s)"`
-- Merge `production` back to `main`, `git checkout main; git merge production`
-- Delete the release branch, `git branch -d release/$VERSION`
+
+- Merge `production` back to `main`; `git checkout main; git merge production`
+
+- Delete the release branch; `git branch -d release/$VERSION`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,17 @@
+# Releasing
+
+- Determine a new version number, `VERSION=...`
+- Checkout `main` and ensure you are up to date, `git checkout main; git pull`
+- Create and checkout a release branch, `git checkout -b release/$VERSION`
+- Update the version number with `poetry version $VERSION`
+- Update the changelog, `scriv collect --edit`
+- Add, commit, and push
+    `git commit -m "Bump version for release v$VERSION"`
+- Fast-forward merge the release branch to the `production` branch
+    `git checkout production && git merge --no-ff release/$VERSION`
+- Create a release tag and push,
+    `git tag -s "v$(poetry version -s)" -m "v$(poetry version -s)"`
+- Create a GitHub release, which will auto-publish to pypi
+    `gh release create "v$(poetry version -s)" --title "v$(poetry version -s)"`
+- Merge `production` back to `main`, `git checkout main; git merge production`
+- Delete the release branch, `git branch -d release/$VERSION`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -33,6 +33,10 @@ _Note: this assumes `origin` is your desired upstream._
 - Create a GitHub release, which will auto-publish to pypi
     `gh release create "v$(poetry version -s)" --title "v$(poetry version -s)"`
 
-- Merge `production` back to `main`; `git checkout main; git merge production`
+- Merge `production` back to `main` by opening and merging a PR:
+
+    ```
+    gh pr create -B main -H production -t "Merge back production->main ($(date +"%Y-%m-%d"))" -b '' -l no-news-is-good-news
+    ```
 
 - Delete the release branch; `git branch -d release/$VERSION`

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -13,10 +13,7 @@ Some commands may not be available until the virtual environment is created and 
 * [Version numbering](#version-numbering)
 * [Priority git branches](#priority-git-branches)
 * [Everyday development](#everyday-development)
-* [Preparing a feature release](#preparing-a-feature-release)
 * [Preparing a hotfix release](#preparing-a-hotfix-release)
-* [Merging release branches](#merging-release-branches)
-* [Publishing the new version](#publishing-the-new-version)
 
 
 ## Version numbering
@@ -76,28 +73,6 @@ git checkout -b "$BRANCH_NAME"
 Feature branches are merged back to `main`, and only to `main`.
 
 
-## Preparing a feature release
-
-When the code or documentation is ready for release, a new feature release will be created.
-Feature releases begin by creating a new branch off of `main`
-(or, alternatively, by branching off an agreed-upon merge commit in `main`).
-
-```shell
-read -p "Enter the feature release version: " NEW_VERSION
-BRANCH_NAME="release/$NEW_VERSION"
-
-# If deploying from main:
-git checkout main
-git pull origin
-git checkout -b "$BRANCH_NAME"
-
-# Alternatively, if deploying from an agreed-upon merge commit:
-git checkout -b "$BRANCH_NAME" <SHA>
-```
-
-Next, proceed to the [Merging release branches](#merging-release-branches) section.
-
-
 ## Preparing a hotfix release
 
 If a bug is found in production and must be fixed immediately, this requires a hotfix release.
@@ -118,74 +93,3 @@ After creating the hotfix branch, fix that bug, create a changelog fragment
 and commit the changes in the hotfix branch!
 
 Next, proceed to the [Merging release branches](#merging-release-branches) section.
-
-
-## Merging release branches
-
-**NOTE**:
-The steps in this document must be performed in a release or hotfix branch.
-See the
-[Preparing a feature release](#preparing-a-feature-release)
-or
-[Preparing a hotfix release](#preparing-a-hotfix-release)
-section for steps to create a release or hotfix branch.
-
-After creating a release or hotfix branch,
-you must follow these steps to merge the branch to `production` and `main`:
-
-1. On the branch that is to be released, prepare the code and documentation for release.
-   1. Bump the version.
-        - If the release is a hotfix, use ``poetry version patch``
-        - If the release is a backwards-compatible change use ``poetry version patch``
-        - If the release is non-backwards compatible, use ``poetry version minor``
-   2. Bump copyright years as appropriate.
-   3. Collect changelog fragments as appropriate.
-   4. Run unit/integration/CI/doc tests as appropriate.
-   5. Commit all changes to git.
-
-2. Push the branch to GitHub.
-
-3. Create a new pull request to merge to `production`.
-   1. Select `production` as the "base" merge branch.
-   2. Select the release or hotfix branch as the "compare" merge branch.
-   3. Wait for CI test results (and approvals, when possible).
-
-      It is the release engineer's discretion to ask for and require PR approvals.
-      A release branch will usually contain code that has already been reviewed, unless it is a hotfix.
-      If the release is a hotfix, it is recommended to get approvals.
-
-      > WARNING: **Merge conflicts**
-      >
-      > Merge conflicts halt the release process when merging to `production`
-      > unless it is a trivial conflict (like the "version" in `pyproject.toml`).
-
-   4. Merge the branch to `production`. Do not delete the branch!
-
-4. Create a new tag and a new release.
-
-   1. Click on the "Releases" section. Then click "Draft a new release".
-   2. Click the "Choose a tag" dropdown, type the new version, and press Enter.
-   3. Select `production` as the target branch.
-   4. Type the new version as the release title.
-   5. Paste the changelog as the release description.
-   6. Click "Publish release" to publish the new tag and release on GitHub.
-
-5. Create a new pull request to merge to `main`.
-
-   1. Select `main` as the "base" merge branch.
-   2. Select the release or hotfix branch as the "compare" merge branch.
-   3. Wait for CI test results (and approvals, if needed).
-
-      > NOTE: **Merge conflicts**
-      >
-      > A merge conflict at this stage does NOT halt the release process.
-      > However, approval is required after resolving the conflict.
-
-   4. Merge the branch to `main`.
-
-6. Delete the release branch.
-
-
-## Publishing the new version
-
-Code updates are automatically published to PyPI when a new release is created on GitHub.


### PR DESCRIPTION
~Simpler process, simpler doc, focused only on what we need.~
~Discard misleading and overly verbose internal documentation.~

---

I've struck most of this changeset in an attempt to reach agreement. I don't find the current documentation at all satisfactory, and I don't want to start carrying out a procedure for a release about which I am unclear.

There are still several steps eliminated here, as I cannot see the _benefit_ of putting the release (which is predicated on the team agreeing to perform a release) through a PR process. I very strongly object to the way that the current process doc is predicated on performing such fundamental activities as _tagging_ via the GitHub GUI. I have no intention of doing that -- and rather than simply _not follow the doc_, I'm trying to true up the doc to my expectations about a single person cutting a release of a library.