### PR TITLE
Eliminate `None` as a return type from authentication methods

### DIFF
--- a/changelog.d/20240607_153946_kurtmckee_eliminate_none_return_type.rst
+++ b/changelog.d/20240607_153946_kurtmckee_eliminate_none_return_type.rst
@@ -1,0 +1,4 @@
+Development
+-----------
+
+- Eliminate ``None`` as a return type from authentication methods.

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -101,4 +101,5 @@ def test_auth_state_caching_across_instances(auth_state, freeze_time, mocked_res
 def test_invalid_grant_exception(auth_state):
     load_response("token-introspect", case="success")
     load_response("token", case="invalid-grant")
-    assert auth_state.get_authorizer_for_scope("doesn't matter") is None
+    with pytest.raises(ValueError):
+        auth_state.get_authorizer_for_scope("doesn't matter")


### PR DESCRIPTION
This is related to the HTTP 429 Too Many Requests story. This is a small bit of disentanglement and simplification, and is scoped to be standalone.


> [!NOTE]
>
> A single test case changed, which might suggest a behavioral change. This is not the case.
>
> The `ValueError` that is now raised is already caught by an ancestor caller:
>
> ```
> WAS:
>
> .groups                                 (catch ValueError)
> `--- ._get_groups_client()              (if None, raise ValueError)
>      `--- .get_authorizer_for_scope()   (return None)
>
> NOW:
>
> .groups                                 (catch ValueError)
> `--- ._get_groups_client()
>      `--- .get_authorizer_for_scope()   (raise ValueError)
> ```
>
> `.groups` is the _ONLY_ caller for `.get_groups_client()`, and `.get_groups_client()` is the _ONLY_ caller of `.get_authorizer_for_scope()`.

Development
-----------

* Eliminate ``None`` as a return type from authentication-related methods.
