### PR TITLE
Remove 'aud' field checking and fields

### DIFF
--- a/changelog.d/20241008_125419_sirosen_remove_expected_audience.rst
+++ b/changelog.d/20241008_125419_sirosen_remove_expected_audience.rst
@@ -1,0 +1,14 @@
+Changes
+-------
+
+- The ``aud`` field of token introspect responses is no longer validated and
+  fields associated with it have been removed. This includes changes to
+  function and class initializer signatures.
+
+  - The ``expected_audience`` field is no longer supported in ``AuthState`` and
+    ``TokenChecker``. It has been removed from the initializers for these
+    classes.
+
+  - ``globus_auth_client_name`` has been removed from ``ActionProviderBlueprint``.
+
+  - ``client_name`` has been removed from ``add_action_routes_to_blueprint``.

--- a/examples/watchasay/app/config.py
+++ b/examples/watchasay/app/config.py
@@ -3,4 +3,3 @@ client_secret = ""
 our_scope = (
     "https://auth.globus.org/scopes/d3a66776-759f-4316-ba55-21725fe37323/action_all"
 )
-token_audience = None

--- a/examples/watchasay/app/provider.py
+++ b/examples/watchasay/app/provider.py
@@ -233,7 +233,6 @@ def create_app():
         blueprint=skeleton_blueprint,
         client_id=config.client_id,
         client_secret=config.client_secret,
-        client_name=None,
         provider_description=provider_description,
         action_run_callback=action_run,
         action_status_callback=action_status,

--- a/examples/whattimeisitrightnow/app/app.py
+++ b/examples/whattimeisitrightnow/app/app.py
@@ -26,9 +26,7 @@ from globus_action_provider_tools.flask.helpers import assign_json_provider
 app = Flask(__name__)
 assign_json_provider(app)
 
-token_checker = TokenChecker(
-    config.client_id, config.client_secret, [config.our_scope], config.token_audience
-)
+token_checker = TokenChecker(config.client_id, config.client_secret, [config.our_scope])
 
 COMPLETE_STATES = (ActionStatusValue.SUCCEEDED, ActionStatusValue.FAILED)
 INCOMPLETE_STATES = (ActionStatusValue.ACTIVE, ActionStatusValue.INACTIVE)

--- a/examples/whattimeisitrightnow/app/config.py
+++ b/examples/whattimeisitrightnow/app/config.py
@@ -1,4 +1,3 @@
 client_id = "16e16447-209a-4825-ae19-25e279d91642"
 client_secret = "SECRET"
 our_scope = "https://auth.globus.org/scopes/16e16447-209a-4825-ae19-25e279d91642/action_all_with_groups"
-token_audience = None

--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -50,20 +50,12 @@ class AuthState:
         auth_client: ConfidentialAppAuthClient,
         bearer_token: str,
         expected_scopes: Iterable[str],
-        expected_audience: str | None = None,
     ) -> None:
         self.auth_client = auth_client
         self.bearer_token = bearer_token
         self.sanitized_token = self.bearer_token[-7:]
         self.expected_scopes = expected_scopes
 
-        # Default to client_id unless expected_audience has been explicitly
-        # provided (supporting legacy clients that may have a different
-        # client name registered with Auth)
-        if expected_audience is None:
-            self.expected_audience = auth_client.client_id
-        else:
-            self.expected_audience = expected_audience
         self.errors: list[Exception] = []
         self._groups_client: GroupsClient | None = None
 
@@ -98,12 +90,6 @@ class AuthState:
                 raise AssertionError(
                     "Token invalid scopes. "
                     f"Expected one of: {self.expected_scopes}, got: {scopes}"
-                )
-            aud = resp.get("aud", [])
-            if self.expected_audience not in aud:
-                raise AssertionError(
-                    "Token not intended for us: "
-                    f"audience={aud}, expected={self.expected_audience}"
                 )
             if "identity_set" not in resp:
                 raise AssertionError("Missing identity_set")
@@ -366,19 +352,10 @@ class AuthState:
 
 class TokenChecker:
     def __init__(
-        self,
-        client_id: str,
-        client_secret: str,
-        expected_scopes: Iterable[str],
-        expected_audience: str | None = None,
+        self, client_id: str, client_secret: str, expected_scopes: Iterable[str]
     ) -> None:
         self.auth_client = ConfidentialAppAuthClient(client_id, client_secret)
         self.default_expected_scopes = frozenset(expected_scopes)
-
-        if expected_audience is None:
-            self.expected_audience = client_id
-        else:
-            self.expected_audience = expected_audience
 
     def check_token(
         self, access_token: str, expected_scopes: Iterable[str] | None = None
@@ -387,6 +364,4 @@ class TokenChecker:
             expected_scopes = self.default_expected_scopes
         else:
             expected_scopes = frozenset(expected_scopes)
-        return AuthState(
-            self.auth_client, access_token, expected_scopes, self.expected_audience
-        )
+        return AuthState(self.auth_client, access_token, expected_scopes)

--- a/src/globus_action_provider_tools/flask/api_helpers.py
+++ b/src/globus_action_provider_tools/flask/api_helpers.py
@@ -106,7 +106,6 @@ def add_action_routes_to_blueprint(
     blueprint: flask.Blueprint,
     client_id: str,
     client_secret: str,
-    client_name: str | None,
     provider_description: ActionProviderDescription,
     action_run_callback: ActionRunCallback,
     action_status_callback: ActionStatusCallback,
@@ -141,13 +140,6 @@ def add_action_routes_to_blueprint(
     ``client_secret`` (*string*)
     A Globus Auth generated ``client_secret`` which will be used when validating input
     request tokens.
-
-    ``client_name`` (*string*) Most commonly, this will be a None value. In the rare,
-    legacy case where a name has been associated with a client_id, it can be provided
-    here. If you are not aware of a name associated with your client_id, it most likely
-    doesn't have one and the value should be None. This will be passed to the
-    (:class:`TokenChecker<globus_action_provider_tools.authentication>`) as the
-    `expected_audience`.
 
     ``provider_description`` (:class:`ActionProviderDescription\
     <globus_action_provider_tools.data_types>`)
@@ -190,7 +182,6 @@ def add_action_routes_to_blueprint(
         client_id=client_id,
         client_secret=client_secret,
         expected_scopes=all_accepted_scopes,
-        expected_audience=client_name,
     )
 
     assign_json_provider(blueprint)

--- a/src/globus_action_provider_tools/flask/apt_blueprint.py
+++ b/src/globus_action_provider_tools/flask/apt_blueprint.py
@@ -53,7 +53,6 @@ class ActionProviderBlueprint(Blueprint):
         self,
         provider_description: ActionProviderDescription,
         *args,
-        globus_auth_client_name: t.Optional[str] = None,
         additional_scopes: t.Iterable[str] = (),
         action_repository: t.Optional[AbstractActionRepository] = None,
         request_lifecycle_hooks: t.Optional[t.List[t.Any]] = None,
@@ -65,13 +64,6 @@ class ActionProviderBlueprint(Blueprint):
 
         :param provider_description: A Provider Description which will be
         returned from introspection calls to this Blueprint.
-
-        :param globus_auth_client_name: The name of the Globus Auth Client (also
-        known as the resource server name). This will be used to validate the
-        intended audience for tokens passed to the operations on this
-        Blueprint. By default, the client id will be used for checkign audience,
-        and unless the client has explicitly been given a resource server name
-        in Globus Auth, this will be proper behavior.
 
         :param additional_scopes: Additional scope strings the Action Provider
         should allow scopes in addition to the one specified by the
@@ -93,7 +85,6 @@ class ActionProviderBlueprint(Blueprint):
             provider_description,
             config=config,
         )
-        self.globus_auth_client_name = globus_auth_client_name
         self.additional_scopes = additional_scopes
         self.config = config
 
@@ -170,7 +161,6 @@ class ActionProviderBlueprint(Blueprint):
             client_id=client_id,
             client_secret=client_secret,
             expected_scopes=scopes,
-            expected_audience=self.globus_auth_client_name,
         )
 
     def _action_introspect(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,6 @@ def config():
         "client_id": canned_responses.mock_client_id(),
         "client_secret": canned_responses.mock_client_secret(),
         "expected_scopes": (canned_responses.mock_scope(),),
-        "expected_audience": canned_responses.mock_expected_audience(),
     }
 
 
@@ -53,7 +52,6 @@ def auth_state(MockAuthClient, config, monkeypatch) -> AuthState:
         client_id=config["client_id"],
         client_secret=config["client_secret"],
         expected_scopes=config["expected_scopes"],
-        expected_audience=config["expected_audience"],
     )
     auth_state = checker.check_token("NOT_A_TOKEN")
 

--- a/tests/data/canned_responses.py
+++ b/tests/data/canned_responses.py
@@ -117,7 +117,3 @@ def mock_client_secret():
 
 def mock_effective_identity() -> str:
     return "00000000-0000-0000-0000-000000000000"
-
-
-def mock_expected_audience() -> str:
-    return "action_provider_tools_automated_tests"

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -9,32 +9,23 @@ from globus_sdk._testing import load_response
 from globus_action_provider_tools.authentication import AuthState, identity_principal
 
 
-def get_auth_state_instance(
-    expected_scopes: t.Iterable[str],
-    expected_audience: str,
-) -> AuthState:
+def get_auth_state_instance(expected_scopes: t.Iterable[str]) -> AuthState:
     return AuthState(
         auth_client=globus_sdk.ConfidentialAppAuthClient("bogus", "bogus"),
         bearer_token="bogus",
         expected_scopes=expected_scopes,
-        expected_audience=expected_audience,
     )
 
 
 @pytest.fixture
 def auth_state(mocked_responses) -> AuthState:
-    """Create an AuthState instance.
-
-    AuthState compares its `expected_scopes` and `expected_audience` values
-    against the values present in an API request and will fail if they don't match.
-    Unfortunately, this currently means that these values are duplicated
-    in the API fixture .yaml files and here.
-    """
+    """Create an AuthState instance."""
 
     AuthState.dependent_tokens_cache.clear()
     AuthState.group_membership_cache.clear()
     AuthState.introspect_cache.clear()
-    return get_auth_state_instance(["expected-scope"], "expected-audience")
+    # note that expected-scope MUST match the fixture data
+    return get_auth_state_instance(["expected-scope"])
 
 
 def test_get_identities(auth_state, freeze_time):
@@ -84,10 +75,7 @@ def test_caching_groups(auth_state, freeze_time, mocked_responses):
 def test_auth_state_caching_across_instances(auth_state, freeze_time, mocked_responses):
     response = freeze_time(load_response("token-introspect", case="success"))
 
-    duplicate_auth_state = get_auth_state_instance(
-        auth_state.expected_scopes,
-        auth_state.expected_audience,
-    )
+    duplicate_auth_state = get_auth_state_instance(auth_state.expected_scopes)
     assert duplicate_auth_state is not auth_state
 
     assert len(auth_state.identities) == len(response.metadata["identities"])

--- a/tests/test_flask_helpers/conftest.py
+++ b/tests/test_flask_helpers/conftest.py
@@ -72,7 +72,6 @@ def add_routes_app(flask_helpers_noauth, auth_state):
         blueprint=bp,
         client_id="bogus",
         client_secret="bogus",
-        client_name=None,
         provider_description=ap_description,
         action_run_callback=mock_action_run_func,
         action_status_callback=mock_action_status_func,


### PR DESCRIPTION
Removing audience checking is safe, in that we remain fully spec
compliant. The field is optional for servers and optional for clients
to validate even when it's present.

The source for the expected audience value is typically the same as
that of the client credentials, and therefore there is no additional
safety (e.g., against credential confusion bugs) being added by
requiring this field. It only serves to add surface area and
therefore complexity.

This is a breaking change, in that the interfaces for the library are
changing to remove a field.
