### PR TITLE
Fix caching and checking of introspect responses

### DIFF
--- a/changelog.d/20241008_171503_sirosen_fix_introspect_check.rst
+++ b/changelog.d/20241008_171503_sirosen_fix_introspect_check.rst
@@ -1,0 +1,19 @@
+Features
+--------
+
+- The token introspect checking and caching performed in ``AuthState`` has
+  been improved.
+
+  - The cache is keyed off of token hashes, rather than raw token strings.
+
+  - The ``exp`` and ``nbf`` values are no longer verified, removing the
+    possibility of incorrect treatment of valid tokens as invalid due to clock
+    drift.
+
+  - Introspect response caching caches the raw response even for invalid
+    tokens, meaning that Action Providers will no longer repeatedly introspect
+    a token once it is known to be invalid.
+
+  - Scope validation raises a new, dedicated error class,
+    ``globus_action_provider_tools.authentication.InvalidTokenScopesError``, on
+    failure.


### PR DESCRIPTION
This change is based on #172 and therefore should be reviewed in series.

---

- Ensure introspect is cached even if 'active=False'
- Don't check claims pointlessly: exp and nbf can fail if your clock is drifted, so it's not safe to be checking them unless users can configure a leeway.
  Also, 'active' tells you everything you need in OAuth2.
- Capture scope validation failures with an exception, not None.
- Cache by token hash, not full token string.
