### PR TITLE
Remove an unreachable code block

### DIFF
--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -244,15 +244,7 @@ class AuthState:
         refresh_token = cast(str, dep_tkn_resp.get("refresh_token"))
         access_token = cast(str, dep_tkn_resp.get("access_token"))
         token_expiration = dep_tkn_resp.get("expires_at_seconds", 0)
-        # IF for some reason the token_expiration comes in a string, or even a string
-        # containing a float representation, try converting to a proper int. If the
-        # conversion is impossible, set expiration to 0 which should force some sort of
-        # refresh as described elsewhere.
-        if not isinstance(token_expiration, int):
-            try:
-                token_expiration = int(float(token_expiration))
-            except ValueError:
-                token_expiration = 0
+
         now = time()
 
         # IF we have an access token, we'll try building an authorizer from it if it is


### PR DESCRIPTION
Without dragging this code too much, this is just not how it works.
`expires_at_seconds` is a computed field provided by the SDK. It's always an int.
