### PR TITLE
Refactor `get_authorizer_for_scope`

### DIFF
--- a/changelog.d/20241011_131741_sirosen_fix_get_authorizer.rst
+++ b/changelog.d/20241011_131741_sirosen_fix_get_authorizer.rst
@@ -1,0 +1,7 @@
+Development
+-----------
+
+- Refactor ``AuthState.get_authorizer_for_scope`` without changing its
+  primary outward semantics. The ``bypass_dependent_token_cache`` argument
+  has been removed from its interface, as it is not necessary to expose
+  with the improved implementation.


### PR DESCRIPTION
Better control where and how dependent token callouts happen, and note with inline FIXME comments several issues which persist even with the refined implementation.

Logically, there is almost no change, although the refactor may make it appear that there is one. `get_authorizer_for_scope` now retries by clearing the cache and fetching new dependent tokens on failure, and has clearer failure semantics.
This happened in the previous code as well -- if the access token is expired and the refresh token is missing, a second call to get dependent tokens is issued. However, due to an inaccurate type annotation (`refresh_token` is `cast(str, ...)`, where it should be `str | None`), it *appears* that there was a previously unreachable behavior -- a retry -- which is now reachable.

In practical fact, these subtleties do not yet make any difference, as `refresh_token` will always be present and will be a string if there is any data at all. Anything else is an invalid and unreachable state, given that refresh tokens are currently always requested.

With the refactor completed, we can tackle separate changes to actually alter behavior.