### PR TITLE
Make mypy stricter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,3 +90,15 @@ filterwarnings = [
     # dateutil, used by freezegun during testing, has a Python 3.12 compatibility issue.
     "ignore:datetime.datetime.utcfromtimestamp\\(\\) is deprecated:DeprecationWarning",
 ]
+
+[tool.mypy]
+sqlite_cache = true
+ignore_missing_imports = true
+disallow_subclassing_any = false
+warn_unreachable = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_return_any = true
+warn_no_return = true
+no_implicit_optional = true
+# disallow_untyped_defs = true

--- a/src/globus_action_provider_tools/data_types.py
+++ b/src/globus_action_provider_tools/data_types.py
@@ -215,7 +215,7 @@ class ActionStatus(BaseModel):
         min_length=1,
         max_length=64,
     )
-    monitor_by: Set[str] | None = Field(
+    monitor_by: Optional[Set[str]] = Field(
         default_factory=set,
         description=(
             "A list of principal URNs containing identities which are allowed to "
@@ -224,7 +224,7 @@ class ActionStatus(BaseModel):
         ),
         regex=principal_urn_regex,
     )
-    manage_by: Set[str] | None = Field(
+    manage_by: Optional[Set[str]] = Field(
         default_factory=set,
         description=(
             "A list of principal URNs containing identities which are allowed "

--- a/src/globus_action_provider_tools/data_types.py
+++ b/src/globus_action_provider_tools/data_types.py
@@ -215,7 +215,7 @@ class ActionStatus(BaseModel):
         min_length=1,
         max_length=64,
     )
-    monitor_by: Set[str] = Field(
+    monitor_by: Set[str] | None = Field(
         default_factory=set,
         description=(
             "A list of principal URNs containing identities which are allowed to "
@@ -224,7 +224,7 @@ class ActionStatus(BaseModel):
         ),
         regex=principal_urn_regex,
     )
-    manage_by: Set[str] = Field(
+    manage_by: Set[str] | None = Field(
         default_factory=set,
         description=(
             "A list of principal URNs containing identities which are allowed "

--- a/src/globus_action_provider_tools/flask/api_helpers.py
+++ b/src/globus_action_provider_tools/flask/api_helpers.py
@@ -68,8 +68,8 @@ log = logging.getLogger(__name__)
 
 
 def _api_operation_for_request(request: flask.Request) -> str:
-    method = request.path.rsplit("/", 1)
-    op_name = method[-1]
+    method: str = request.path.rsplit("/", 1)
+    op_name: str = method[-1]
     return op_name
 
 

--- a/src/globus_action_provider_tools/flask/apt_blueprint.py
+++ b/src/globus_action_provider_tools/flask/apt_blueprint.py
@@ -298,7 +298,7 @@ class ActionProviderBlueprint(Blueprint):
 
         try:
             if action:
-                result = self.action_resume_callback(action, g.auth_state)  # type: ignore
+                result = self.action_resume_callback(action, g.auth_state)
             else:
                 result = self.action_resume_callback(action_id, g.auth_state)  # type: ignore
         except AttributeError:
@@ -354,7 +354,7 @@ class ActionProviderBlueprint(Blueprint):
 
         try:
             if action:
-                result = self.action_status_callback(action, g.auth_state)  # type: ignore
+                result = self.action_status_callback(action, g.auth_state)
             else:
                 result = self.action_status_callback(action_id, g.auth_state)  # type: ignore
         except AttributeError:
@@ -397,7 +397,7 @@ class ActionProviderBlueprint(Blueprint):
 
         try:
             if action:
-                result = self.action_cancel_callback(action, g.auth_state)  # type: ignore
+                result = self.action_cancel_callback(action, g.auth_state)
             else:
                 result = self.action_cancel_callback(action_id, g.auth_state)  # type: ignore
         except AttributeError:
@@ -452,7 +452,7 @@ class ActionProviderBlueprint(Blueprint):
 
         try:
             if action:
-                result = self.action_release_callback(action, g.auth_state)  # type: ignore
+                result = self.action_release_callback(action, g.auth_state)
             else:
                 result = self.action_release_callback(action_id, g.auth_state)  # type: ignore
         except ValidationError as ve:
@@ -516,10 +516,10 @@ class ActionProviderBlueprint(Blueprint):
         Executes an action_saver to store the ActionStatus in the specified
         backend.
         """
-        if isinstance(result, ActionStatus):
-            action = result
-        elif isinstance(result, tuple):
+        action = result
+        if isinstance(result, tuple) and len(result) > 0:
             action = result[0]
+
         if not isinstance(action, ActionStatus):
             current_app.logger.warning(
                 f"Attempted to save a non ActionStatus: {action}"

--- a/src/globus_action_provider_tools/flask/helpers.py
+++ b/src/globus_action_provider_tools/flask/helpers.py
@@ -133,12 +133,12 @@ def blueprint_error_handler(exc: Exception) -> ViewReturn:
     # ActionProviderToolsException is the base class for HTTP-based exceptions,
     # return those directly
     if isinstance(exc, ActionProviderToolsException):
-        return exc  # type: ignore
+        return exc
 
     # If a component in the toolkit throw's an unhandled AuthenticationError,
     # replace it with a Flask-based response
     if isinstance(exc, AuthenticationError):
-        return UnauthorizedRequest()  # type: ignore
+        return UnauthorizedRequest()
 
     current_app.logger.exception("Handling unexpected exception", exc_info=True)
     # Handle unexpected Exceptions in a somewhat predictable way

--- a/src/globus_action_provider_tools/utils.py
+++ b/src/globus_action_provider_tools/utils.py
@@ -11,6 +11,7 @@ class TypedTTLCache(t.Generic[T]):
     A tiny wrapper class which provides a type-checked layer on top of TTLCache.
     This allows us to know and enforce the types of cached objects.
     """
+
     def __init__(self, *, maxsize: int, ttl: int) -> None:
         self._cache: cachetools.TTLCache = cachetools.TTLCache(maxsize=maxsize, ttl=ttl)
 

--- a/src/globus_action_provider_tools/utils.py
+++ b/src/globus_action_provider_tools/utils.py
@@ -30,6 +30,9 @@ class TypedTTLCache(t.Generic[T]):
     def __contains__(self, key: str) -> bool:
         return key in self._cache
 
+    def clear(self) -> None:
+        self._cache.clear()
+
 
 def now_isoformat():
     return str(datetime.datetime.now(datetime.timezone.utc).isoformat())

--- a/src/globus_action_provider_tools/utils.py
+++ b/src/globus_action_provider_tools/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import typing as t
 

--- a/src/globus_action_provider_tools/utils.py
+++ b/src/globus_action_provider_tools/utils.py
@@ -1,4 +1,33 @@
 import datetime
+import typing as t
+
+import cachetools
+
+T = t.TypeVar("T")
+
+
+class TypedTTLCache(t.Generic[T]):
+    """
+    A tiny wrapper class which provides a type-checked layer on top of TTLCache.
+    This allows us to know and enforce the types of cached objects.
+    """
+    def __init__(self, *, maxsize: int, ttl: int) -> None:
+        self._cache: cachetools.TTLCache = cachetools.TTLCache(maxsize=maxsize, ttl=ttl)
+
+    def get(self, key: str) -> T | None:
+        return self._cache.get(key)
+
+    def __setitem__(self, key: str, value: T) -> None:
+        self._cache[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._cache[key]
+
+    def __getitem__(self, key: str) -> T:
+        return self._cache[key]  # type: ignore[no-any-return]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._cache
 
 
 def now_isoformat():

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ skip_install = true
 deps =
     -r requirements/mypy/requirements.txt
 commands =
-    mypy --ignore-missing-imports src/ tests/
+    mypy src/ tests/
 
 
 [testenv:docs]


### PR DESCRIPTION
- turn on a variety of mypy strictness flags, but stay short of
  `disallow_untyped_defs` -- which is why we aren't in strict mode
- `tox r -e mypy` does not pass any CLI flags
- cleanup numerous annotations
- in some cases, make minor implementation ordering adjustments to
  make things pass
- Put a small shim in place over TTLCache to allow its contents to be
  type checked
