### PR TITLE
hotfix/0.19.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,10 +10,28 @@ Unreleased changes are documented in files in the `changelog.d`_ directory.
 
 ..  scriv-insert-here
 
+.. _changelog-0.19.1:
+
+0.19.1 — 2024-10-22
+===================
+
+Bugfixes
+--------
+
+- When introspecting tokens, allow the introspected scopes to be a superset of required scopes.
+
+  A bug in the scope comparison code flipped the logic;
+  if a user consented to scopes A and B and the action provider required only scope A,
+  the comparison would fail *as if A and B were required but only A had been consented to*.
+
+  This is now fixed.
+
 .. _changelog-0.19.0:
 
 0.19.0 — 2024-10-18
 ===================
+
+**YANKED**
 
 Features
 --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "globus-action-provider-tools"
-version = "0.19.0"
+version = "0.19.1"
 description = "Tools to help developers build services that implement the Action Provider specification."
 authors = [
     "Globus Team <support@globus.org>",

--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -124,9 +124,9 @@ class AuthState:
         """
         # validate scopes, ensuring that the token provided accords with the service's
         # notion of what operations exist and are supported
-        scopes = set(introspect_result.get("scope", "").split())
-        if any(s not in self.expected_scopes for s in scopes):
-            raise InvalidTokenScopesError(self.expected_scopes, frozenset(scopes))
+        scopes = frozenset(introspect_result.get("scope", "").split())
+        if not scopes.issuperset(self.expected_scopes):
+            raise InvalidTokenScopesError(self.expected_scopes, scopes)
 
     @property
     def effective_identity(self) -> str | None:

--- a/tests/api-fixtures/token-introspect.yaml
+++ b/tests/api-fixtures/token-introspect.yaml
@@ -15,7 +15,7 @@ success:
     audience: &success-audience
       - expected-audience
     scope: &success-scope
-      expected-scope
+      expected-scope bonus-scope
     identities: &success-identities
       - 2c3c6ce2-96ee-4104-9ba8-8d7a5f5e3c7b
       - 2106ff4e-6a6f-4215-b0d4-aa78dcc43cc8

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -175,4 +175,12 @@ def test_invalid_scopes_error():
         auth_state.introspect_token()
 
     assert excinfo.value.expected_scopes == {"bad-scope"}
-    assert excinfo.value.actual_scopes == {"expected-scope"}
+    assert excinfo.value.actual_scopes == {"expected-scope", "bonus-scope"}
+
+
+def test_required_scopes_may_be_a_subset_of_token_scopes():
+    """Verify that required scopes may be a subset of token scopes."""
+
+    auth_state_instance = get_auth_state_instance(["expected-scope"])
+    load_response("token-introspect", case="success")
+    auth_state_instance.introspect_token()


### PR DESCRIPTION
Bugfixes
--------

- When introspecting tokens, allow the introspected scopes to be a superset of required scopes.

  A bug in the scope comparison code flipped the logic;
  if a user consented to scopes A and B and the action provider required only scope A,
  the comparison would fail *as if A and B were required but only A had been consented to*.

  This is now fixed.
