### PR TITLE
Refactor groups caching for simplicity and perf

### DIFF
--- a/changelog.d/20241025_172707_sirosen_improve_groups_caching.rst
+++ b/changelog.d/20241025_172707_sirosen_improve_groups_caching.rst
@@ -1,0 +1,7 @@
+Changes
+-------
+
+- Group caching behavior in the ``AuthState`` class has been improved to ensure
+  that the cache is checked before any external operations (e.g., dependent
+  token callouts) are required. The cache now uses the token hash as its key,
+  rather than a dependent token.

--- a/tests/api-fixtures/groups-my_groups.yaml
+++ b/tests/api-fixtures/groups-my_groups.yaml
@@ -42,3 +42,10 @@ success:
         ],
       },
     ]
+
+failure:
+  service: groups
+  path: /groups/my_groups
+  method: GET
+  json: {"message": "Internal server error."}
+  status: 500


### PR DESCRIPTION
This order of evaluation is cleaner/simpler to reason about and has improved performance in specific cases, when the cache is warm and a dependent token is absent (e.g., the group cache was populated at the end of the lifetime for a cached dependent token).

This changeset refrains from changing the established behavior of converting groups API errors to the empty group set, but it does make this behavior more visible.
