### PR TITLE
Fix erroneous use of dependent refresh tokens

### DIFF
--- a/changelog.d/20241025_185333_sirosen_do_not_use_refresh_tokens.rst
+++ b/changelog.d/20241025_185333_sirosen_do_not_use_refresh_tokens.rst
@@ -1,0 +1,14 @@
+Bugfixes
+--------
+
+- Action Provider Tools no longer requests Dependent Refresh Tokens in
+  contexts where Access Tokens are sufficient. As a result of this fix, the
+  AuthState dependent token cache will never contain dependent refresh tokens.
+
+Deprecations
+------------
+
+- The ``required_authorizer_expiration_time`` parameter to
+  ``get_authorizer_for_scope`` is deprecated. Given token expiration and
+  caching lifetimes, it was not possible for this parameter to have any effect
+  based on its prior documented usage.

--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -219,7 +219,7 @@ class AuthState:
             warnings.warn(
                 "`required_authorizer_expiration_time` has no effect and will be removed in a future version.",
                 DeprecationWarning,
-                stacklevel=1,
+                stacklevel=2,
             )
 
         retrieved_from_cache, dependent_tokens = self._get_cached_dependent_tokens()

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -98,6 +98,19 @@ def test_auth_state_caching_across_instances(auth_state, freeze_time, mocked_res
     assert len(mocked_responses.calls) == 1
 
 
+def test_(auth_state):
+    load_response("token-introspect", case="success")
+    load_response("token", case="success")
+    with pytest.warns(
+        DeprecationWarning,
+        match="`required_authorizer_expiration_time` has no effect and will be removed",
+    ):
+        auth_state.get_authorizer_for_scope(
+            "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships",
+            required_authorizer_expiration_time=60,
+        )
+
+
 def test_invalid_grant_exception(auth_state):
     load_response("token-introspect", case="success")
     load_response("token", case="invalid-grant")

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -128,7 +128,6 @@ def test_dependent_token_callout_success_fixes_bad_cache(auth_state):
         "foo_scope": {
             "expires_at_seconds": time.time() + 100,
             "access_token": "foo_AT",
-            "refresh_token": "foo_RT",
         }
     }
     auth_state.dependent_tokens_cache[auth_state._dependent_token_cache_key] = (
@@ -146,15 +145,14 @@ def test_dependent_token_callout_success_fixes_bad_cache(auth_state):
                 "scope": "bar_scope",
                 "expires_at_seconds": time.time() + 100,
                 "access_token": "bar_AT",
-                "refresh_token": "bar_RT",
             }
         ],
     ).add()
     # now get the 'bar_scope' authorizer
     authorizer = auth_state.get_authorizer_for_scope("bar_scope")
 
-    # it should be a refresh token authorizer and the cache should be updated
-    assert isinstance(authorizer, globus_sdk.RefreshTokenAuthorizer)
+    # it should be an access token authorizer and the cache should be updated
+    assert isinstance(authorizer, globus_sdk.AccessTokenAuthorizer)
     cache_value = auth_state.dependent_tokens_cache[
         auth_state._dependent_token_cache_key
     ]


### PR DESCRIPTION
The previous code (here, almost entirely removed) requested dependent refresh tokens unconditionally. These were then stored in a 47 hour cache, and there was never an update to the cache to refresh these credentials. Access tokens last for 48 hours, meaning that with the prior cache parameters, it was not realistically possible to reach the point of requiring a refresh via expiration. (A refresh triggered by token revocation would fail, and therefore is not worthy of special attention.)

Similar to the impossibility of a normal refresh, the timing requirement expressed by the `required_authorizer_expiration_time` parameter was more or less impossible to trigger in normal usage. With the default value of 60 seconds, the only way it could fire requires an hour to pass between the request being received and the dependent token for that request being retrieved. Therefore, this parameter is no longer checked, and emits a DeprecationWarning if used explicitly.
