### PR TITLE
Introduce 'ClientFactory' to tune transport-layer parameters attached to any of the client-building components

### DIFF
--- a/changelog.d/20241104_170625_sirosen_client_factory_sets_params.rst
+++ b/changelog.d/20241104_170625_sirosen_client_factory_sets_params.rst
@@ -9,8 +9,8 @@ Features
 
   - The number of retries for both client types is reduced to 1 (from an
     SDK-default of 5).
-  - The http timeout is reduced to 30 seconds (from an SDK-default of 60s).
-  - The max sleep duration is reduced to 5 seconds (fram an SDK-default of
+  - The HTTP timeout is reduced to 30 seconds (from an SDK default of 60s).
+  - The max sleep duration is reduced to 5 seconds (from an SDK default of
     10s).
   - ActionProviderConfig, AuthStateBuilder, and AuthState are all customized to
     accept a ClientFactory, and to use the client factory for any client

--- a/changelog.d/20241104_170625_sirosen_client_factory_sets_params.rst
+++ b/changelog.d/20241104_170625_sirosen_client_factory_sets_params.rst
@@ -1,0 +1,17 @@
+Features
+--------
+
+- A new component, ``ClientFactory`` is now exposed in
+  ``globus_action_provider_tools.client_factory``. This allows users to
+  customize the transport-layer settings used for Auth and Groups clients which
+  are constructed by the Action Provider Tools library, and sets initial
+  parameters for this tuning.
+
+  - The number of retries for both client types is reduced to 1 (from an
+    SDK-default of 5).
+  - The http timeout is reduced to 30 seconds (from an SDK-default of 60s).
+  - The max sleep duration is reduced to 5 seconds (fram an SDK-default of
+    10s).
+  - ActionProviderConfig, AuthStateBuilder, and AuthState are all customized to
+    accept a ClientFactory, and to use the client factory for any client
+    building operations.

--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -13,6 +13,7 @@ from globus_sdk import (
     GlobusHTTPResponse,
 )
 
+from .client_factory import ClientFactory
 from .utils import TypedTTLCache
 
 log = logging.getLogger(__name__)
@@ -70,14 +71,17 @@ class AuthState:
         auth_client: ConfidentialAppAuthClient,
         bearer_token: str,
         expected_scopes: frozenset[str],
+        client_factory: ClientFactory | None = None,
     ) -> None:
         self.auth_client = auth_client
         self.bearer_token = bearer_token
         self.sanitized_token = self.bearer_token[-7:]
         self.expected_scopes = expected_scopes
+        self._client_factory = (
+            client_factory if client_factory is not None else ClientFactory()
+        )
 
         self.errors: list[Exception] = []
-        self._groups_client: globus_sdk.GroupsClient | None = None
 
     @functools.cached_property
     def _token_hash(self) -> str:
@@ -148,20 +152,32 @@ class AuthState:
         )
         if group_set is None:
             try:
-                groups_client = self._get_groups_client()
-            except (globus_sdk.GlobusAPIError, KeyError, ValueError) as err:
-                # Only warning level, because this could be normal state of
-                # affairs for a system that doesn't use or care about groups.
-                log.warning(
-                    "Unable to determine groups membership. Setting groups to {}",
+                groups_client = self._groups_client
+            except (globus_sdk.GlobusAPIError, KeyError, ValueError):
+                # FIXME: currently this is treated as a soft-fail and produces the
+                #        empty set
+                #
+                # this fails to distinguish between a supported case:
+                #   AP does not have a dependent Groups scope
+                #   and has no desire to handle group-auth
+                #
+                # and an error case:
+                #   attempting to get Groups tokens fails
+                #   but the AP actually *does* intend to support group-auth
+                #
+                # this should become an error in a future release
+                log.error(
+                    "Failed to load GroupsClient. Falling back to empty-set for groups.",
                     exc_info=True,
                 )
-                self.errors.append(err)
                 return frozenset()
 
             try:
                 group_data = groups_client.get_my_groups()
             except globus_sdk.GlobusAPIError:
+                # FIXME: this error handler should be removed in a future release
+                #
+                # ignoring Groups API callout failures should not be default-on behavior
                 log.warning(
                     "failed to get groups, treating groups as '{}'", exc_info=True
                 )
@@ -260,14 +276,12 @@ class AuthState:
         self.dependent_tokens_cache[self._dependent_token_cache_key] = token_response
         return (False, token_response)
 
-    def _get_groups_client(self) -> globus_sdk.GroupsClient:
-        if self._groups_client is not None:
-            return self._groups_client
+    @functools.cached_property
+    def _groups_client(self) -> globus_sdk.GroupsClient:
         authorizer = self.get_authorizer_for_scope(
             globus_sdk.GroupsClient.scopes.view_my_groups_and_memberships
         )
-        self._groups_client = globus_sdk.GroupsClient(authorizer=authorizer)
-        return self._groups_client
+        return self._client_factory.make_groups_client(authorizer=authorizer)
 
     @staticmethod
     def group_in_principal_list(principal_list: Iterable[str]) -> bool:
@@ -317,9 +331,12 @@ class AuthStateBuilder:
         self,
         auth_client: globus_sdk.ConfidentialAppAuthClient,
         expected_scopes: Iterable[str],
+        *,
+        client_factory: ClientFactory | None = None,
     ) -> None:
         self.auth_client = auth_client
         self.default_expected_scopes = frozenset(expected_scopes)
+        self.client_factory = client_factory
 
     def build(
         self, access_token: str, expected_scopes: Iterable[str] | None = None
@@ -328,4 +345,9 @@ class AuthStateBuilder:
             expected_scopes = self.default_expected_scopes
         else:
             expected_scopes = frozenset(expected_scopes)
-        return AuthState(self.auth_client, access_token, expected_scopes)
+        return AuthState(
+            self.auth_client,
+            access_token,
+            expected_scopes,
+            client_factory=self.client_factory,
+        )

--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -77,9 +77,7 @@ class AuthState:
         self.bearer_token = bearer_token
         self.sanitized_token = self.bearer_token[-7:]
         self.expected_scopes = expected_scopes
-        self._client_factory = (
-            client_factory if client_factory is not None else ClientFactory()
-        )
+        self._client_factory = client_factory or ClientFactory()
 
         self.errors: list[Exception] = []
 

--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -334,7 +334,7 @@ class AuthStateBuilder:
     ) -> None:
         self.auth_client = auth_client
         self.default_expected_scopes = frozenset(expected_scopes)
-        self.client_factory = client_factory
+        self.client_factory = client_factory or ClientFactory()
 
     def build(
         self, access_token: str, expected_scopes: Iterable[str] | None = None

--- a/src/globus_action_provider_tools/client_factory.py
+++ b/src/globus_action_provider_tools/client_factory.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import typing as t
+import uuid
+
+import globus_sdk
+
+_DEFAULT_AUTH_PARAMS: tuple[tuple[str, t.Any], ...] = (
+    ("http_timeout", 30),
+    ("max_retries", 1),
+    ("max_sleep", 5),
+)
+_DEFAULT_GROUPS_PARAMS: tuple[tuple[str, t.Any], ...] = (
+    ("http_timeout", 30),
+    ("max_retries", 1),
+    ("max_sleep", 5),
+)
+
+
+class ClientFactory:
+    """
+    This helper defines methods which create relevant SDK client objects for use
+    in an ActionProviderBlueprint and other contexts.
+
+    The default implementation sets transport parameters on initialization.
+
+    The client factory can be modified or replaced on an ActionProviderBlueprint
+    in order to customize client construction.
+    """
+
+    def make_confidential_app_auth_client(
+        self, client_id: str | uuid.UUID, client_secret: str
+    ) -> globus_sdk.ConfidentialAppAuthClient:
+        return globus_sdk.ConfidentialAppAuthClient(
+            client_id=client_id,
+            client_secret=client_secret,
+            transport_params={k: v for k, v in _DEFAULT_AUTH_PARAMS},
+        )
+
+    def make_groups_client(
+        self,
+        authorizer: (
+            globus_sdk.AccessTokenAuthorizer | globus_sdk.RefreshTokenAuthorizer | None
+        ),
+    ) -> globus_sdk.GroupsClient:
+        return globus_sdk.GroupsClient(
+            authorizer=authorizer,
+            transport_params={k: v for k, v in _DEFAULT_GROUPS_PARAMS},
+        )

--- a/src/globus_action_provider_tools/client_factory.py
+++ b/src/globus_action_provider_tools/client_factory.py
@@ -5,17 +5,6 @@ import uuid
 
 import globus_sdk
 
-_DEFAULT_AUTH_PARAMS: tuple[tuple[str, t.Any], ...] = (
-    ("http_timeout", 30),
-    ("max_retries", 1),
-    ("max_sleep", 5),
-)
-_DEFAULT_GROUPS_PARAMS: tuple[tuple[str, t.Any], ...] = (
-    ("http_timeout", 30),
-    ("max_retries", 1),
-    ("max_sleep", 5),
-)
-
 
 class ClientFactory:
     """
@@ -28,13 +17,24 @@ class ClientFactory:
     in order to customize client construction.
     """
 
+    DEFAULT_AUTH_TRANSPORT_PARAMS: tuple[tuple[str, t.Any], ...] = (
+        ("http_timeout", 30),
+        ("max_retries", 1),
+        ("max_sleep", 5),
+    )
+    DEFAULT_GROUPS_TRANSPORT_PARAMS: tuple[tuple[str, t.Any], ...] = (
+        ("http_timeout", 30),
+        ("max_retries", 1),
+        ("max_sleep", 5),
+    )
+
     def make_confidential_app_auth_client(
         self, client_id: str | uuid.UUID, client_secret: str
     ) -> globus_sdk.ConfidentialAppAuthClient:
         return globus_sdk.ConfidentialAppAuthClient(
             client_id=client_id,
             client_secret=client_secret,
-            transport_params={k: v for k, v in _DEFAULT_AUTH_PARAMS},
+            transport_params={k: v for k, v in self.DEFAULT_AUTH_TRANSPORT_PARAMS},
         )
 
     def make_groups_client(
@@ -45,5 +45,5 @@ class ClientFactory:
     ) -> globus_sdk.GroupsClient:
         return globus_sdk.GroupsClient(
             authorizer=authorizer,
-            transport_params={k: v for k, v in _DEFAULT_GROUPS_PARAMS},
+            transport_params={k: v for k, v in self.DEFAULT_GROUPS_TRANSPORT_PARAMS},
         )

--- a/src/globus_action_provider_tools/client_factory.py
+++ b/src/globus_action_provider_tools/client_factory.py
@@ -34,7 +34,7 @@ class ClientFactory:
         return globus_sdk.ConfidentialAppAuthClient(
             client_id=client_id,
             client_secret=client_secret,
-            transport_params={k: v for k, v in self.DEFAULT_AUTH_TRANSPORT_PARAMS},
+            transport_params=dict(self.DEFAULT_AUTH_TRANSPORT_PARAMS),
         )
 
     def make_groups_client(
@@ -45,5 +45,5 @@ class ClientFactory:
     ) -> globus_sdk.GroupsClient:
         return globus_sdk.GroupsClient(
             authorizer=authorizer,
-            transport_params={k: v for k, v in self.DEFAULT_GROUPS_TRANSPORT_PARAMS},
+            transport_params=dict(self.DEFAULT_GROUPS_TRANSPORT_PARAMS),
         )

--- a/src/globus_action_provider_tools/flask/config.py
+++ b/src/globus_action_provider_tools/flask/config.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+from globus_action_provider_tools.client_factory import ClientFactory
+
 
 @dataclasses.dataclass(frozen=True)
 class ActionProviderConfig:
@@ -9,6 +11,9 @@ class ActionProviderConfig:
     # provided data but making the error message less useful for debugging in the
     # process.
     scrub_validation_errors: bool = True
+    # by default, the config provides a base ClientFactory as the constructor for
+    # Auth and Groups clients, with default parameters
+    client_factory: ClientFactory = ClientFactory()
 
 
 DEFAULT_CONFIG = ActionProviderConfig()

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -30,7 +30,7 @@ _NO_RETRY_FACTORY = NoRetryClientFactory()
 
 
 @pytest.fixture
-def get_auth_state_instance():
+def get_auth_state_instance() -> t.Callable[..., AuthState]:
     def _func(
         expected_scopes: t.Iterable[str],
         client_factory: ClientFactory = _NO_RETRY_FACTORY,
@@ -54,7 +54,9 @@ def _clear_auth_state_cache():
 
 
 @pytest.fixture
-def auth_state(mocked_responses, get_auth_state_instance) -> AuthState:
+def auth_state(
+    mocked_responses, get_auth_state_instance: t.Callable[..., AuthState]
+) -> AuthState:
     """Create an AuthState instance."""
     # note that expected-scope MUST match the fixture data
     return get_auth_state_instance(["expected-scope"])

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -192,8 +192,10 @@ def test_dependent_token_callout_500_retry_behavior(
         authorizer = auth_state.get_authorizer_for_scope("golden-ticket")
         assert isinstance(authorizer, globus_sdk.AccessTokenAuthorizer)
     else:
-        with pytest.raises(globus_sdk.GlobusAPIError):
+        with pytest.raises(globus_sdk.GlobusAPIError) as excinfo:
             auth_state.get_authorizer_for_scope("golden-ticket")
+        error = excinfo.value
+        assert error.http_status == 500
 
 
 def test_dependent_token_callout_success_fixes_bad_cache(auth_state):


### PR DESCRIPTION
Introduce a ClientFactory pattern encoding params

A ClientFactory is a newly-defined interface specific to AP Tools which can construct ConfidentialAppAuthClient and GroupsClient instances with pre-baked initialization parameters.
In our case, the default implementation is customized to provide transport-layer parameters tuning the retry and timeout behaviors.

A user can implement the same interface and pass an alternative ClientFactory to the blueprint config, allowing them freedom to more tightly control the construction of Auth and Groups clients within AP Tools.

Minimal changes are made to add `client_factory` as an init-time argument for AuthStateBuilder and AuthState, and `client_factory` is added as an attribute of the blueprint config (ActionProviderConfig).
The blueprint will pass its configured factory to AuthStateBuilder, and the AuthStateBuilder will pass its configured factory to AuthState.

In order to keep tests fast, the ClientFactory is subclassed for testing, with implementations which set low-retry and 0-sleep behaviors via the supported params. Only one new test is introduced to validate the retry-once behavior of the default configuration.
