### PR TITLE
Pin werkzeug when testing the minimum Flask version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,8 @@ fail_under = 83
 filterwarnings = [
     "error",
 
-    # Minimum Flask versions interact with werkzeug in a now-deprecated manner.
-    "ignore:The '__version__' attribute is deprecated:DeprecationWarning",
+    # Minimum Flask versions use a werkzeug version that triggers AST warnings.
+    "ignore:.+? is deprecated and will be removed:DeprecationWarning:werkzeug|ast",
 
     # dateutil, used by freezegun during testing, has a Python 3.12 compatibility issue.
     "ignore:datetime.datetime.utcfromtimestamp\\(\\) is deprecated:DeprecationWarning",

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ extras =
 deps =
     -r requirements/test/requirements.txt
     minimum_flask: flask==2.3.0
+    minimum_flask: werkzeug==2.3.0
 commands = coverage run -m pytest {posargs}
 
 


### PR DESCRIPTION
This resolves CI failures caused by an unpinned werkzeug when testing the minimum Flask version ([recent example](https://github.com/globus/action-provider-tools/actions/runs/11628788643/job/32384575116#step:9:821)).