### PR TITLE
Only instantiate a default JSON encoder once

### DIFF
--- a/src/globus_action_provider_tools/data_types.py
+++ b/src/globus_action_provider_tools/data_types.py
@@ -279,6 +279,9 @@ class ActionStatus(BaseModel):
         return self.status in (ActionStatusValue.SUCCEEDED, ActionStatusValue.FAILED)
 
 
+_DEFAULT_JSON_ENCODER = json.JSONEncoder()
+
+
 def convert_to_json(o: Any) -> Any:
     if isinstance(o, AbstractSet):
         return list(o)
@@ -290,7 +293,7 @@ def convert_to_json(o: Any) -> Any:
         return o.isoformat()
     elif isinstance(o, datetime.timedelta):
         return isodate.duration_isoformat(o)
-    return json.JSONEncoder().default(o)
+    return _DEFAULT_JSON_ENCODER.default(o)
 
 
 class ActionProviderJsonEncoder(json.JSONEncoder):


### PR DESCRIPTION
This is unnecessarily slow. Without addressing any potential broader
issues, simply make sure to only instantiate it once.
