### PR TITLE
Deprecate the 'get_dependent_tokens' method

### DIFF
--- a/changelog.d/20241203_153200_sirosen_deprecate_dependent_tokens_method.rst
+++ b/changelog.d/20241203_153200_sirosen_deprecate_dependent_tokens_method.rst
@@ -1,0 +1,5 @@
+Deprecations
+------------
+
+*   ``AuthState.get_dependent_tokens`` is now deprecated. It will be removed in
+    a future release.

--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -192,9 +192,13 @@ class AuthState:
         Returns OAuthTokenResponse representing the dependent tokens associated
         with a particular access token.
         """
-        # TODO: consider deprecating and removing this method
-        # it is no longer used by `get_authorizer_for_scope()`, which now uses logic which cannot
+        # this mehtod is no longer used by `get_authorizer_for_scope()`, which now uses logic which cannot
         # be satisfied by the contract provided by this method
+        warnings.warn(
+            "`get_dependent_tokens` is deprecated and will be removed in a future version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         if not bypass_cache_lookup:
             resp = self.dependent_tokens_cache.get(self._dependent_token_cache_key)


### PR DESCRIPTION
It is no longer used, and searches over code built on Action Provider
Tools indicates that no dependents are using this method directly.
