### PR TITLE
Eliminate use of the `^` syntax for dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,13 @@ whattimeisit-provider = "examples.flask.whattimeisitrightnow.app.app:main"
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-globus-sdk="^3.9.0"
-jsonschema = "^4.17"
-pyyaml = "^6"
-pydantic = "^1.7.3"
-isodate = "^0.6.0"
-cachetools = "^5.0"
-flask = {version = "^2.3.0", optional = true}
+globus-sdk=">=3.9,<4"
+jsonschema = ">=4.17,<5"
+pyyaml = ">=6,<7"
+pydantic = ">=1.7.3,<2"
+isodate = ">=0.6,<0.7"
+cachetools = ">=5.0,<6"
+flask = {version = ">=2.3,<3", optional = true}
 
 [tool.poetry.extras]
 flask = ["flask"]


### PR DESCRIPTION
`^` is a special symbol for Poetry, not part of the packaging
specifications. As a result, it is always being translated when we do
package builds, and may follow unintuitive rules.

Replace it with standardized package specifiers, which make our
statically declared metadata match the rendered PKG-INFO and wheel
metadata.

A build confirms that the current specifiers are very slightly
different. For example, globus-sdk was `>=3.9.0,<4.0.0`. This is
semantically the same as what we have written for almost all cases. In
theory, there could be some corner cases around values like `4.0.0a1`
and other such values, but none are obvious or likely.

`poetry lock --no-update` makes no change to the lockfile, confirming
that the values have not moved significantly.
