### PR TITLE
Remove public export of names from 'utils'

### DIFF
--- a/changelog.d/20241205_115915_sirosen_remove_utils_names.rst
+++ b/changelog.d/20241205_115915_sirosen_remove_utils_names.rst
@@ -1,0 +1,5 @@
+Breaking changes
+----------------
+
+*   The ``now_isoformat`` and ``principal_urn_regex`` names are no longer
+    publicly exported by the library.

--- a/src/globus_action_provider_tools/__init__.py
+++ b/src/globus_action_provider_tools/__init__.py
@@ -6,7 +6,6 @@ from globus_action_provider_tools.data_types import (
     ActionStatus,
     ActionStatusValue,
 )
-from globus_action_provider_tools.utils import now_isoformat, principal_urn_regex
 
 __all__ = [
     "AuthState",
@@ -16,6 +15,4 @@ __all__ = [
     "ActionRequest",
     "ActionStatus",
     "ActionStatusValue",
-    "principal_urn_regex",
-    "now_isoformat",
 ]


### PR DESCRIPTION
'now_isoformat' and 'principal_urn_regex' are unnecessary bits of public API surface. They are hereby removed from the top-level package `__init__.py`.

---

A cursory check shows that downstream consumers are not using these names directly (nor should they be).
