### PR TITLE
Eagerly check token validity and handle invalid tokens in flask helpers

### DIFF
--- a/changelog.d/20250207_122449_sirosen_eagerly_check_authn.rst
+++ b/changelog.d/20250207_122449_sirosen_eagerly_check_authn.rst
@@ -1,0 +1,18 @@
+Breaking changes
+----------------
+
+*   The ``AuthState`` object now introspects its token when initialized. This
+    results in more eager error behaviors, as a failed introspect will now
+    raise an error immediately, rather than on the first usage which triggers
+    an implicit introspect.
+
+    Callers who are explicitly handling invalid token errors, like
+    ``InactiveTokenError``, should put their handling around ``AuthState``
+    construction rather than around ``AuthState`` attribute and method usage.
+
+*   The provided ``FlaskAuthStateBuilder`` used by the provided flask blueprint
+    now handles ``InactiveTokenError`` and ``InvalidTokenScopesError`` and will
+    raise an ``AuthenticationError`` if these are encountered.
+    The error handler in the provided blueprint translates these into
+    ``UnauthorizedRequest`` exceptions, which render as HTTP 401 Unauthorized
+    responses.

--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -81,6 +81,8 @@ class AuthState:
 
         self.errors: list[Exception] = []
 
+        self._token_data = self.introspect_token()
+
     @functools.cached_property
     def _token_hash(self) -> str:
         return _hash_token(self.bearer_token)
@@ -143,14 +145,12 @@ class AuthState:
 
     @property
     def effective_identity(self) -> str:
-        tkn_details = self.introspect_token()
-        effective = identity_principal(tkn_details["sub"])
+        effective = identity_principal(self._token_data["sub"])
         return effective
 
     @property
     def identities(self) -> frozenset[str]:
-        tkn_details = self.introspect_token()
-        return frozenset(map(identity_principal, tkn_details["identity_set"]))
+        return frozenset(map(identity_principal, self._token_data["identity_set"]))
 
     @property
     def principals(self) -> frozenset[str]:

--- a/src/globus_action_provider_tools/flask/helpers.py
+++ b/src/globus_action_provider_tools/flask/helpers.py
@@ -82,9 +82,9 @@ class FlaskAuthStateBuilder(AuthStateBuilder):
         try:
             return super().build(access_token)
         except InvalidTokenScopesError as err:
-            raise AuthenticationError("token had invalid scopes") from err
+            raise AuthenticationError("Token has invalid scopes") from err
         except InactiveTokenError as err:
-            raise AuthenticationError("token was invalid, expired, or revoked") from err
+            raise AuthenticationError("Token is invalid, expired, or revoked") from err
 
 
 def parse_query_args(

--- a/src/globus_action_provider_tools/flask/helpers.py
+++ b/src/globus_action_provider_tools/flask/helpers.py
@@ -12,7 +12,12 @@ import jsonschema
 from flask import Request, current_app, jsonify
 from pydantic import BaseModel, ValidationError
 
-from globus_action_provider_tools.authentication import AuthState, AuthStateBuilder
+from globus_action_provider_tools.authentication import (
+    AuthState,
+    AuthStateBuilder,
+    InactiveTokenError,
+    InvalidTokenScopesError,
+)
 from globus_action_provider_tools.data_types import (
     ActionProviderDescription,
     ActionProviderJsonEncoder,
@@ -74,7 +79,12 @@ class FlaskAuthStateBuilder(AuthStateBuilder):
         if not 10 <= len(access_token) <= 2048:
             raise UnverifiedAuthenticationError("Bearer token length is unexpected")
 
-        return super().build(access_token)
+        try:
+            return super().build(access_token)
+        except InvalidTokenScopesError as err:
+            raise AuthenticationError("token had invalid scopes") from err
+        except InactiveTokenError as err:
+            raise AuthenticationError("token was invalid, expired, or revoked") from err
 
 
 def parse_query_args(

--- a/tests/api-fixtures/token-introspect.yaml
+++ b/tests/api-fixtures/token-introspect.yaml
@@ -23,6 +23,7 @@ success:
       - 84b6fc41-022a-42c2-ae31-ab41cd94d08f
       - ecad897d-eb0b-4970-aa12-ac523c3567d9
       - 02d1f36c-a798-410b-95fe-3a9ea1a83610
+      - f7e81526-1610-47e2-a7c5-b071db77ca47
     effective-id: &success-effective-id
       f7e81526-1610-47e2-a7c5-b071db77ca47
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import globus_sdk
 import pytest
 import responses
 import yaml
-from globus_sdk._testing import RegisteredResponse, register_response_set
+from globus_sdk._testing import RegisteredResponse, load_response, register_response_set
 
 from globus_action_provider_tools.authentication import AuthState, AuthStateBuilder
 
@@ -33,7 +33,9 @@ def config():
 
 @pytest.fixture
 @mock.patch("globus_sdk.ConfidentialAppAuthClient")
-def auth_state(MockAuthClient, config, monkeypatch) -> AuthState:
+def auth_state(
+    MockAuthClient, config, monkeypatch, introspect_success_response
+) -> AuthState:
     # FIXME: the comment below is a lie, assess and figure out what is being said
     #
     # Mock the introspection first because that gets called as soon as we create
@@ -113,6 +115,11 @@ def mocked_responses() -> responses.RequestsMock:
 
     with responses.mock:
         yield responses.mock
+
+
+@pytest.fixture
+def introspect_success_response(mocked_responses):
+    return load_response("token-introspect", case="success")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,13 @@ import typing as t
 from unittest import mock
 
 import freezegun
-import globus_sdk
 import pytest
 import responses
 import yaml
 from globus_sdk._testing import RegisteredResponse, load_response, register_response_set
 
-from globus_action_provider_tools.authentication import AuthState, AuthStateBuilder
+from globus_action_provider_tools.authentication import AuthState
+from globus_action_provider_tools.client_factory import ClientFactory
 
 from .data import canned_responses
 
@@ -20,6 +20,14 @@ try:
     import flask  # noqa: F401
 except ModuleNotFoundError:
     collect_ignore = ["flask"]
+
+
+class NoRetryClientFactory(ClientFactory):
+    DEFAULT_AUTH_TRANSPORT_PARAMS = (("max_retries", 0),)
+    DEFAULT_GROUPS_TRANSPORT_PARAMS = (("max_retries", 0),)
+
+
+_NO_RETRY_FACTORY = NoRetryClientFactory()
 
 
 @pytest.fixture
@@ -31,40 +39,69 @@ def config():
     }
 
 
+@pytest.fixture(autouse=True)
+def mocked_responses() -> responses.RequestsMock:
+    """Mock all requests.
+
+    The default `responses.mock` object is returned,
+    which allows tests to access various properties of the mock.
+    For example, they might check the number of intercepted `.calls`.
+    """
+
+    with responses.mock:
+        yield responses.mock
+
+
 @pytest.fixture
-@mock.patch("globus_sdk.ConfidentialAppAuthClient")
+def introspect_success_response(mocked_responses):
+    return load_response("token-introspect", case="success")
+
+
+@pytest.fixture
+def dependent_token_success_response(mocked_responses):
+    return load_response("token", case="success")
+
+
+@pytest.fixture
+def groups_success_response(mocked_responses):
+    return load_response("groups-my_groups", case="success")
+
+
+@pytest.fixture
+def get_auth_state_instance() -> t.Callable[..., AuthState]:
+    def _func(
+        expected_scopes: t.Iterable[str],
+        client_factory: ClientFactory = _NO_RETRY_FACTORY,
+    ) -> AuthState:
+        client = client_factory.make_confidential_app_auth_client("bogus", "bogus")
+        return AuthState(
+            auth_client=client,
+            bearer_token="bogus",
+            expected_scopes=frozenset(expected_scopes),
+            client_factory=client_factory,
+        )
+
+    return _func
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_state_cache():
+    AuthState.dependent_tokens_cache.clear()
+    AuthState.group_membership_cache.clear()
+    AuthState.introspect_cache.clear()
+
+
+@pytest.fixture
 def auth_state(
-    MockAuthClient, config, monkeypatch, introspect_success_response
+    mocked_responses,
+    get_auth_state_instance: t.Callable[..., AuthState],
+    introspect_success_response,
+    dependent_token_success_response,
+    groups_success_response,
 ) -> AuthState:
-    # FIXME: the comment below is a lie, assess and figure out what is being said
-    #
-    # Mock the introspection first because that gets called as soon as we create
-    # an AuthStateBuilder
-    client = MockAuthClient.return_value
-    client.oauth2_token_introspect.return_value = (
-        canned_responses.introspect_response()()
-    )
-
-    # Mock the dependent_tokens and list_groups functions bc they get used when
-    # creating a GroupsClient
-    client.oauth2_get_dependent_tokens.return_value = (
-        canned_responses.dependent_token_response()()
-    )
-    monkeypatch.setattr(
-        globus_sdk.GroupsClient, "get_my_groups", canned_responses.groups_response()
-    )
-
-    # Create an AuthStateBuilder to be used to create a mocked auth_state object
-    builder = AuthStateBuilder(client, expected_scopes=config["expected_scopes"])
-    auth_state = builder.build("NOT_A_TOKEN")
-
-    # Reset the call count because check_token implicitly calls oauth2_token_introspect
-    client.oauth2_token_introspect.call_count = 0
-
-    # Mock out this AuthState instance's GroupClient
-    # auth_state._groups_client = GroupsClient(authorizer=None)
-    # auth_state._groups_client.list_groups = canned_responses.groups_response()
-    return auth_state
+    """Create an AuthState instance."""
+    # note that expected-scope MUST match the fixture data
+    return get_auth_state_instance(["expected-scope"])
 
 
 @pytest.fixture
@@ -102,24 +139,6 @@ def register_api_fixtures():
     for yaml_file in (pathlib.Path(__file__).parent / "api-fixtures").rglob("*.yaml"):
         response_set = yaml.safe_load(yaml_file.read_text())
         register_response_set(yaml_file.stem, response_set)
-
-
-@pytest.fixture(autouse=True)
-def mocked_responses() -> responses.RequestsMock:
-    """Mock all requests.
-
-    The default `responses.mock` object is returned,
-    which allows tests to access various properties of the mock.
-    For example, they might check the number of intercepted `.calls`.
-    """
-
-    with responses.mock:
-        yield responses.mock
-
-
-@pytest.fixture
-def introspect_success_response(mocked_responses):
-    return load_response("token-introspect", case="success")
 
 
 @pytest.fixture

--- a/tests/flask/test_flask_auth_state_builder.py
+++ b/tests/flask/test_flask_auth_state_builder.py
@@ -49,10 +49,10 @@ def test_bogus_authorization_headers_are_rejected_without_io(authorization_heade
 @pytest.mark.parametrize(
     "underlying_error, expect_message",
     (
-        (InactiveTokenError("foo"), "token was invalid, expired, or revoked"),
+        (InactiveTokenError("foo"), "Token is invalid, expired, or revoked"),
         (
             InvalidTokenScopesError(frozenset(["foo"]), frozenset(["bar"])),
-            "token had invalid scopes",
+            "Token has invalid scopes",
         ),
     ),
 )

--- a/tests/flask/test_routes.py
+++ b/tests/flask/test_routes.py
@@ -10,7 +10,6 @@ are in fact implemented.
 import flask
 import flask.testing
 import pytest
-from globus_sdk._testing import load_response
 
 from .ap_client import ActionProviderClient
 from .app_utils import (
@@ -22,9 +21,12 @@ from .app_utils import (
 @pytest.mark.parametrize("api_version", ["1.0", "1.1"])
 @pytest.mark.parametrize("use_pydantic_schema", [True, False])
 def test_routes_conform_to_api(
-    freeze_time, request, aptb_app, api_version: str, use_pydantic_schema: bool
+    introspect_success_response,
+    request,
+    aptb_app,
+    api_version: str,
+    use_pydantic_schema: bool,
 ):
-    freeze_time(load_response("token-introspect", case="success"))
     _, bp = list(aptb_app.blueprints.items())[0]
     if use_pydantic_schema:
         bp.input_schema = ActionProviderPydanticInputSchema

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -65,7 +65,6 @@ def test_caching_groups(auth_state, mocked_responses, groups_success_response):
 def test_auth_state_caching_across_instances(
     get_auth_state_instance,
     auth_state,
-    freeze_time,
     mocked_responses,
     introspect_success_response,
 ):

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -11,6 +11,11 @@ from globus_action_provider_tools.data_types import ActionStatus, ActionStatusVa
 from globus_action_provider_tools.errors import AuthenticationError
 
 
+@pytest.fixture
+def random_identity_urn():
+    return f"urn:globus:auth:identity:{uuid.uuid4()}"
+
+
 def test_creator_can_access(auth_state):
     status = ActionStatus(
         status=ActionStatusValue.SUCCEEDED,
@@ -25,10 +30,10 @@ def test_creator_can_access(auth_state):
     authorize_action_access_or_404(status, auth_state)
 
 
-def test_monitor_by_can_access(auth_state):
+def test_monitor_by_can_access(auth_state, random_identity_urn):
     status = ActionStatus(
         status=ActionStatusValue.SUCCEEDED,
-        creator_id=auth_state.effective_identity,
+        creator_id=random_identity_urn,
         monitor_by={auth_state.effective_identity},
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
@@ -40,10 +45,10 @@ def test_monitor_by_can_access(auth_state):
     authorize_action_access_or_404(status, auth_state)
 
 
-def test_unauthorized_access(auth_state):
+def test_unauthorized_access(auth_state, random_identity_urn):
     status = ActionStatus(
         status=ActionStatusValue.SUCCEEDED,
-        creator_id=f"urn:globus:auth:identity:{uuid.uuid4()}",
+        creator_id=random_identity_urn,
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
         release_after="P30D",
@@ -69,10 +74,10 @@ def test_creator_can_manage(auth_state):
     authorize_action_management_or_404(status, auth_state)
 
 
-def test_manage_by_can_access(auth_state):
+def test_manage_by_can_access(auth_state, random_identity_urn):
     status = ActionStatus(
         status=ActionStatusValue.SUCCEEDED,
-        creator_id=f"urn:globus:auth:identity:{uuid.uuid4()}",
+        creator_id=random_identity_urn,
         manage_by={auth_state.effective_identity},
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
@@ -84,10 +89,10 @@ def test_manage_by_can_access(auth_state):
     authorize_action_management_or_404(status, auth_state)
 
 
-def test_unauthorized_management(auth_state):
+def test_unauthorized_management(auth_state, random_identity_urn):
     status = ActionStatus(
         status=ActionStatusValue.SUCCEEDED,
-        creator_id=f"urn:globus:auth:identity:{uuid.uuid4()}",
+        creator_id=random_identity_urn,
         start_time=str(datetime.datetime.now().isoformat()),
         completion_time=str(datetime.datetime.now().isoformat()),
         release_after="P30D",


### PR DESCRIPTION
This changeset makes one primary breaking change and calls out another (more subtle) one as well.

The first and most notable change here is that `AuthState` now calls `AuthState.introspect_token()` on init.
This removes error behaviors which were previously lazy -- for example, the first access to `AuthState.effective_identity` could raise an error.

Instead, users of `AuthState` should anticipate that the token has already been validated.
This does not guarantee that no calls to the `AuthState` will do IO and result in errors -- notably the codepath which reaches out to Groups is intentionally left untouched here for two reasons:

1. To limit the scope and scale of this change (and release)
2. To ensure that services which have no need for Groups information are not calling out to Groups (current supposition is that almost no AP usages actually interrogate Groups and we do not wish to change that)

Secondarily, now that `AuthState(...)` can raise an error, it is clearly possible to handle that gracefully in the `FlaskAuthStateBuilder`.
That component now translates the generic errors which are used by `AuthState` into an appropriate error for the flask components, which then gets handled and translated into an `Unauthorized` error in the default handler.
Because `FlaskAuthStateBuilder` has new and different error raising behavior, it is also noted as a breaking change.

---

In the course of testing this, I also addressed some unnecessarily aggressive mocking in the testsuite, which resulted in a number of tests evaluating against mocks when it is perfectly feasible for them to evaluate against the real `AuthState` object.

---

_NB: I assessed some other paths to resolving the issues with uncaught errors, like modifying the flask-blueprint error handler more extensively.
Although many such options are reasonable, my determination was that they do not solve the underlying issue, which is the ability of this object to make errors appear on property access at unpredictable times in the application lifecycle._
