### PR TITLE
Remove `required_authorizer_expiration_time`

### DIFF
--- a/changelog.d/20250207_172718_sirosen_remove_deprecated_parameter.rst
+++ b/changelog.d/20250207_172718_sirosen_remove_deprecated_parameter.rst
@@ -1,0 +1,6 @@
+Breaking changes
+----------------
+
+*   The ``required_authorizer_expiration_time`` parameter for
+    ``AuthState.get_authorizer_for_scope`` has been removed. In recent
+    releases it had no effect and emitted deprecation warnings.

--- a/src/globus_action_provider_tools/authentication.py
+++ b/src/globus_action_provider_tools/authentication.py
@@ -231,11 +231,7 @@ class AuthState:
         self.dependent_tokens_cache[self._dependent_token_cache_key] = resp
         return resp
 
-    def get_authorizer_for_scope(
-        self,
-        scope: str,
-        required_authorizer_expiration_time: int | None = None,
-    ) -> AccessTokenAuthorizer:
+    def get_authorizer_for_scope(self, scope: str) -> AccessTokenAuthorizer:
         """
         Get dependent tokens for the caller's token, then retrieve token data for the
         requested scope and attempt to build an authorizer from that data.
@@ -244,18 +240,10 @@ class AuthState:
         building authorizers succeeds.
 
         :param scope: The scope for which an authorizer is being requested
-        :param required_authorizer_expiration_time: Deprecated parameter. Has no effect.
 
         :raises ValueError: If the dependent token data for the caller does not match
             the requested scope.
         """
-        if required_authorizer_expiration_time is not None:
-            warnings.warn(
-                "`required_authorizer_expiration_time` has no effect and will be removed in a future version.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
         retrieved_from_cache, dependent_tokens = self._get_cached_dependent_tokens()
 
         # if the dependent token data (which could have been cached) failed to meet

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -83,17 +83,6 @@ def test_auth_state_caching_across_instances(
     assert len(mocked_responses.calls) == 1
 
 
-def test_deprecation_warning_on_required_authorizer_expiration_time(auth_state):
-    with pytest.warns(
-        DeprecationWarning,
-        match="`required_authorizer_expiration_time` has no effect and will be removed",
-    ):
-        auth_state.get_authorizer_for_scope(
-            "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships",
-            required_authorizer_expiration_time=60,
-        )
-
-
 def test_invalid_grant_exception(auth_state, introspect_success_response):
     get_response_set("token").lookup("invalid-grant").replace()
     with pytest.raises(globus_sdk.GlobusAPIError):


### PR DESCRIPTION
This deprecated parameter has no effect. For users who are broken by the update, they should just remove any use of the parameter.

---

Because #205 will necessitate a release containing breaking changes, I have examined other changes which we have planned in the past which would require such a release.
I discounted several as being too likely to cause actual breakage and need high-effort resolution, but this one is trivial for our downstreams to handle and therefore does not pose the same issues.
